### PR TITLE
refactored community_user tests, added util funcs

### DIFF
--- a/backend/main/community_user_test.go
+++ b/backend/main/community_user_test.go
@@ -21,6 +21,13 @@ func TestCreateCommunityUsers(t *testing.T) {
 	clearTable("community_users")
 
 	communityStruct := otu.GenerateCommunityStruct("account")
+
+	//create the author before generating the payload
+	var createCommunityStruct models.CreateCommunityRequestPayload
+	createCommunityStruct.Community = *communityStruct
+	author := []string{"0x01cf0e2f2f715450"}
+	createCommunityStruct.Additional_authors = &author
+
 	communityPayload := otu.GenerateCommunityPayload("account", communityStruct)
 
 	response := otu.CreateCommunityAPI(communityPayload)
@@ -29,13 +36,6 @@ func TestCreateCommunityUsers(t *testing.T) {
 	//Parse Community
 	var community models.Community
 	json.Unmarshal(response.Body.Bytes(), &community)
-
-	//Generate the user, admin must be the signer
-	userStruct := otu.GenerateCommunityUserStruct("user1", "author")
-	userPayload := otu.GenerateCommunityUserPayload("account", userStruct)
-
-	response = otu.CreateCommunityUserAPI(community.ID, userPayload)
-	checkResponseCode(t, http.StatusCreated, response.Code)
 
 	//Query the community
 	response = otu.GetCommunityUsersAPI(community.ID)
@@ -103,6 +103,13 @@ func TestDeleteUserFromCommunity(t *testing.T) {
 	clearTable("community_users")
 
 	communityStruct := otu.GenerateCommunityStruct("account")
+
+	//create the author before generating the payload
+	var createCommunityStruct models.CreateCommunityRequestPayload
+	createCommunityStruct.Community = *communityStruct
+	author := []string{"0x01cf0e2f2f715450"}
+	createCommunityStruct.Additional_authors = &author
+
 	communityPayload := otu.GenerateCommunityPayload("account", communityStruct)
 
 	response := otu.CreateCommunityAPI(communityPayload)
@@ -115,10 +122,6 @@ func TestDeleteUserFromCommunity(t *testing.T) {
 	userStruct := otu.GenerateCommunityUserStruct("user1", "author")
 	userPayload := otu.GenerateCommunityUserPayload("account", userStruct)
 
-	response = otu.CreateCommunityUserAPI(community.ID, userPayload)
-	checkResponseCode(t, http.StatusCreated, response.Code)
-
-	//use same userPayload previously generated
 	response = otu.DeleteUserFromCommunityAPI(
 		community.ID,
 		utils.UserOneAddr,

--- a/backend/main/community_user_test.go
+++ b/backend/main/community_user_test.go
@@ -1,127 +1,144 @@
 package main
 
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/brudfyi/flow-voting-tool/main/models"
+	"github.com/brudfyi/flow-voting-tool/main/shared"
+	"github.com/brudfyi/flow-voting-tool/main/test_utils"
+	utils "github.com/brudfyi/flow-voting-tool/main/test_utils"
+	"github.com/stretchr/testify/assert"
+)
+
 ////////////////////
 // CommunityUsers //
 ////////////////////
 
-// func TestCommunityUsersCreateCommunity(t *testing.T) {
-// 	clearTable("communities")
-// 	clearTable("community_users")
-// 	communityId := addCommunities(1)[0]
+func TestCreateCommunityUsers(t *testing.T) {
+	clearTable("communities")
+	clearTable("community_users")
 
-// 	req, _ := http.NewRequest("GET", "/communities/"+strconv.Itoa(communityId)+"/users", nil)
-// 	response := executeRequest(req)
+	communityStruct := otu.GenerateCommunityStruct("account")
+	communityPayload := otu.GenerateCommunityPayload("account", communityStruct)
 
-// 	checkResponseCode(t, http.StatusOK, response.Code)
+	response := otu.CreateCommunityAPI(communityPayload)
+	checkResponseCode(t, http.StatusCreated, response.Code)
 
-// 	var payload shared.PaginatedResponse
-// 	json.Unmarshal(response.Body.Bytes(), &payload)
+	//Parse Community
+	var community models.Community
+	json.Unmarshal(response.Body.Bytes(), &community)
 
-// 	assert.Equal(t, 3, payload.Count)
-// }
+	//Generate the user, admin must be the signer
+	userStruct := otu.GenerateCommunityUserStruct("user1", "author")
+	userPayload := otu.GenerateCommunityUserPayload("account", userStruct)
 
-// func TestAddAuthorAdmin(t *testing.T) {
-// 	clearTable("communities")
-// 	clearTable("community_users")
-// 	otu := utils.NewOverflowTest(t, &A)
-// 	communityId := addCommunities(1)[0]
+	response = otu.CreateCommunityUserAPI(community.ID, userPayload)
+	checkResponseCode(t, http.StatusCreated, response.Code)
 
-// 	// emulator-account is the community admin by default
-// 	payload := otu.GenerateValidCommunityUserPayload(communityId, "user1", "account", "author")
-// 	response := otu.CreateCommunityUser(1, payload)
-// 	checkResponseCode(t, http.StatusCreated, response.Code)
+	//Query the community
+	response = otu.GetCommunityUsersAPI(community.ID)
+	checkResponseCode(t, http.StatusOK, response.Code)
 
-// 	var m map[string]interface{}
-// 	json.Unmarshal(response.Body.Bytes(), &m)
+	//Parse the response
+	var p test_utils.PaginatedResponseWithUser
+	json.Unmarshal(response.Body.Bytes(), &p)
 
-// 	if m["error"] != nil {
-// 		t.Errorf("Error msg: %v\n", m["error"])
-// 	}
-// 	if m["communityId"] == nil {
-// 		t.Errorf("Expected community_user communityId to exist. Got '%v'", m["communityId"])
-// 	}
-// 	if m["addr"] != utils.DefaultCommunityUserStruct.Addr {
-// 		t.Errorf("Expected community_user addr to be '%s'. Got '%v'", utils.DefaultCommunityUserStruct.Addr, m["addr"])
-// 	}
-// 	if m["userType"] != utils.DefaultUserType {
-// 		t.Errorf("Expected community_user userType to be '%s'. Got '%v'", *&utils.DefaultUserType, m["userType"])
-// 	}
+	for _, user := range p.Data {
+		if utils.DefaultAuthor == user {
+			assert.Equal(t, utils.DefaultAuthor, user)
+		}
+	}
+}
 
-// 	// the id is compared to 1.0 because JSON unmarshaling converts numbers to
-// 	// floats, when the target is a map[string]interface{}
-// 	if m["communityId"] != 1.0 {
-// 		t.Errorf("Expected communityId to be '1'. Got '%v'", m["communityId"])
-// 	}
-// }
+func TestGetCommunityUsers(t *testing.T) {
+	clearTable("communities")
+	clearTable("community_users")
 
-// func TestGetCommunityUsers(t *testing.T) {
-// 	clearTable("communities")
-// 	clearTable("community_users")
-// 	communityId := addCommunities(1)[0]
-// 	addCommunityUsers(communityId, 1)
+	communityStruct := otu.GenerateCommunityStruct("account")
+	communityPayload := otu.GenerateCommunityPayload("account", communityStruct)
 
-// 	req, _ := http.NewRequest("GET", "/communities/"+strconv.Itoa(communityId)+"/users", nil)
-// 	response := executeRequest(req)
+	response := otu.CreateCommunityAPI(communityPayload)
+	checkResponseCode(t, http.StatusCreated, response.Code)
 
-// 	checkResponseCode(t, http.StatusOK, response.Code)
+	var community models.Community
+	json.Unmarshal(response.Body.Bytes(), &community)
 
-// 	var m shared.PaginatedResponse
-// 	json.Unmarshal(response.Body.Bytes(), &m)
+	response = otu.GetCommunityUsersAPI(community.ID)
+	checkResponseCode(t, http.StatusOK, response.Code)
 
-// 	if m.Count != 1 {
-// 		t.Errorf("Expected count to be '1'. Got '%v'", m.Count)
-// 	}
-// 	if m.TotalRecords != 1 {
-// 		t.Errorf("Expected totalRecords to be '1'. Got '%v'", m.TotalRecords)
-// 	}
-// 	if len(m.Data.([]interface{})) != 1 {
-// 		actual := len(m.Data.([]interface{}))
-// 		t.Errorf("Expected len of Data to be '1'. Got '%v'", actual)
-// 	}
-// }
+	var p test_utils.PaginatedResponseWithUser
+	json.Unmarshal(response.Body.Bytes(), &p)
 
-// func TestGetUserCommunities(t *testing.T) {
-// 	clearTable("communities")
-// 	clearTable("community_users")
-// 	communityId := addCommunities(1)[0]
-// 	addCommunityUsers(communityId, 1)
+	// three user roles created by default
+	// admin, author and member
+	assert.Equal(t, 3, len(p.Data))
+}
 
-// 	req, _ := http.NewRequest("GET", "/users/"+utils.ServiceAccountAddress+"/communities", nil)
-// 	response := executeRequest(req)
+func TestGetUserCommunities(t *testing.T) {
+	clearTable("communities")
+	clearTable("community_users")
 
-// 	checkResponseCode(t, http.StatusOK, response.Code)
+	communityStruct := otu.GenerateCommunityStruct("account")
+	communityPayload := otu.GenerateCommunityPayload("account", communityStruct)
 
-// 	var m shared.PaginatedResponse
-// 	json.Unmarshal(response.Body.Bytes(), &m)
+	response := otu.CreateCommunityAPI(communityPayload)
+	checkResponseCode(t, http.StatusCreated, response.Code)
 
-// 	if m.Count != 1 {
-// 		t.Errorf("Expected count to be '1'. Got '%v'", m.Count)
-// 	}
-// 	if m.TotalRecords != 1 {
-// 		t.Errorf("Expected totalRecords to be '1'. Got '%v'", m.TotalRecords)
-// 	}
-// 	if len(m.Data.([]interface{})) != 1 {
-// 		actual := len(m.Data.([]interface{}))
-// 		t.Errorf("Expected len of Data to be '1'. Got '%v'", actual)
-// 	}
-// }
+	var community models.Community
+	json.Unmarshal(response.Body.Bytes(), &community)
 
-// func TestDeleteUserFromCommunity(t *testing.T) {
-// 	clearTable("communities")
-// 	clearTable("community_users")
-// 	communityId := addCommunities(1)[0]
-// 	addCommunityUsers(communityId, 1)
+	response = otu.GetUserCommunitiesAPI(utils.AdminAddr)
+	checkResponseCode(t, http.StatusOK, response.Code)
 
-// 	payload := utils.GenerateValidDeleteCommunityUserPayload(communityId)
-// 	req, _ := http.NewRequest("DELETE", "/communities/"+strconv.Itoa(communityId)+"/users/"+utils.ServiceAccountAddress, bytes.NewBuffer(payload))
-// 	response := executeRequest(req)
+	var p shared.PaginatedResponse
+	json.Unmarshal(response.Body.Bytes(), &p)
 
-// 	checkResponseCode(t, http.StatusOK, response.Code)
+	assert.Equal(t, 3, p.TotalRecords)
+}
 
-// 	var m map[string]interface{}
-// 	json.Unmarshal(response.Body.Bytes(), &m)
+func TestDeleteUserFromCommunity(t *testing.T) {
+	clearTable("communities")
+	clearTable("community_users")
 
-// 	if m["status"] != "ok" {
-// 		t.Errorf("Expected status to be 'ok'. Got '%v'", m["status"])
-// 	}
-// }
+	communityStruct := otu.GenerateCommunityStruct("account")
+	communityPayload := otu.GenerateCommunityPayload("account", communityStruct)
+
+	response := otu.CreateCommunityAPI(communityPayload)
+	checkResponseCode(t, http.StatusCreated, response.Code)
+
+	var community models.Community
+	json.Unmarshal(response.Body.Bytes(), &community)
+
+	//generate the user, admin must be the signer
+	userStruct := otu.GenerateCommunityUserStruct("user1", "author")
+	userPayload := otu.GenerateCommunityUserPayload("account", userStruct)
+
+	response = otu.CreateCommunityUserAPI(community.ID, userPayload)
+	checkResponseCode(t, http.StatusCreated, response.Code)
+
+	//use same userPayload previously generated
+	response = otu.DeleteUserFromCommunityAPI(
+		community.ID,
+		utils.UserOneAddr,
+		"author",
+		userPayload,
+	)
+	checkResponseCode(t, http.StatusOK, response.Code)
+
+	//Query the community
+	response = otu.GetCommunityUsersAPI(community.ID)
+	checkResponseCode(t, http.StatusOK, response.Code)
+
+	//Parse the response
+	var p test_utils.PaginatedResponseWithUser
+	json.Unmarshal(response.Body.Bytes(), &p)
+
+	// assert that the user does not have the role of author
+	for _, user := range p.Data {
+		if user.Addr == utils.UserOneAddr {
+			assert.False(t, user.User_type == "author")
+		}
+	}
+}

--- a/backend/main/test_utils/community_user_utils.go
+++ b/backend/main/test_utils/community_user_utils.go
@@ -1,0 +1,72 @@
+package test_utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"time"
+
+	"github.com/brudfyi/flow-voting-tool/main/models"
+)
+
+var DefaultAuthor = models.CommunityUser{
+	Community_id: 1,
+	Addr:         "0x01cf0e2f2f715450",
+	User_type:    "author",
+}
+
+func (otu *OverflowTestUtils) GenerateCommunityUserPayload(signer string, user *models.CommunityUser) *models.CommunityUserPayload {
+
+	account, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", signer))
+	signingAddr := fmt.Sprintf("0x%s", account.Address().String())
+	timestamp := fmt.Sprint(time.Now().UnixNano() / int64(time.Millisecond))
+	compositeSignatures := otu.GenerateCompositeSignatures(signer, timestamp)
+
+	var signedPayload = models.CommunityUserPayload{
+		CommunityUser:        *user,
+		Timestamp:            timestamp,
+		Composite_signatures: compositeSignatures,
+		Signing_addr:         signingAddr,
+	}
+
+	return &signedPayload
+}
+
+func (otu *OverflowTestUtils) GenerateCommunityUserStruct(accountName string, userType string) *models.CommunityUser {
+	account, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", accountName))
+
+	// this does a deep copy
+	communityUser := models.CommunityUser{
+		Community_id: 1,
+		Addr:         "0x" + account.Address().String(),
+		User_type:    userType,
+	}
+
+	return &communityUser
+}
+
+func (otu *OverflowTestUtils) CreateCommunityUserAPI(id int, payload *models.CommunityUserPayload) *httptest.ResponseRecorder {
+	json, _ := json.Marshal(payload)
+	req, _ := http.NewRequest("POST", "/communities/"+strconv.Itoa(id)+"/users", bytes.NewBuffer(json))
+	req.Header.Set("Content-Type", "application/json")
+
+	response := otu.ExecuteRequest(req)
+	return response
+}
+
+func (otu *OverflowTestUtils) GetUserCommunitiesAPI(addr string) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest("GET", "/users/"+addr+"/communities", nil)
+	response := otu.ExecuteRequest(req)
+	return response
+}
+
+func (otu *OverflowTestUtils) DeleteUserFromCommunityAPI(id int, addr string, userType string, payload *models.CommunityUserPayload) *httptest.ResponseRecorder {
+	json, _ := json.Marshal(payload)
+	req, _ := http.NewRequest("DELETE", "/communities/"+strconv.Itoa(id)+"/users/"+addr+"/"+userType, bytes.NewBuffer(json))
+	req.Header.Set("Content-Type", "application/json")
+	response := otu.ExecuteRequest(req)
+	return response
+}

--- a/backend/main/test_utils/community_utils.go
+++ b/backend/main/test_utils/community_utils.go
@@ -12,6 +12,17 @@ import (
 	"github.com/brudfyi/flow-voting-tool/main/models"
 )
 
+type PaginatedResponseWithUser struct {
+	Data         []models.CommunityUser `json:"data"`
+	Start        int                    `json:"start"`
+	Count        int                    `json:"count"`
+	TotalRecords int                    `json:"totalRecords"`
+	Next         int                    `json:"next"`
+}
+
+var AdminAddr = "0xf8d6e0586b0a20c7"
+var UserOneAddr = "0x01cf0e2f2f715450"
+
 var nameUpdated = "TestDAO - updated"
 var category = "dao"
 var logo = "toad.jpeg"
@@ -30,6 +41,7 @@ var termsAndConditions = "termsAndConditions"
 var DefaultCommunity = models.Community{
 	Name: "TestDAO", Category: &category, Body: &body, Creator_addr: "<replace>", Logo: &logo, Slug: &slug,
 }
+
 var UpdatedCommunity = models.Community{
 	Name: nameUpdated, Logo: &logoUpdated, Banner_img_url: &banner,
 	Website_url: &website, Twitter_url: &twitter, Github_url: &github, Discord_url: &discord,
@@ -88,6 +100,12 @@ func (otu *OverflowTestUtils) GetCommunityAPI(id int) *httptest.ResponseRecorder
 	return response
 }
 
+func (otu *OverflowTestUtils) GetCommunityUsersAPI(id int) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest("GET", "/communities/"+strconv.Itoa(id)+"/users", nil)
+	response := otu.ExecuteRequest(req)
+	return response
+}
+
 // func GenerateValidUpdateCommunityPayload(addr string) []byte {
 // 	// this does a deep copy
 // 	community := ValidUpdateCommunityStruct
@@ -102,4 +120,3 @@ func (otu *OverflowTestUtils) GetCommunityAPI(id int) *httptest.ResponseRecorder
 // 	jsonStr, _ := json.Marshal(community)
 // 	fmt.Printf("payload: %v\n", string(jsonStr))
 // 	return []byte(jsonStr)
-// }


### PR DESCRIPTION
With this new pattern there is some repeating code in the tests, for example when a communityStruct is created, then payload, then api call. As this code is repeating, is it useful to abstract it away into a reusable utils func?