### PR TITLE
feat(front): group proposals into two list when filter has "all" selected

### DIFF
--- a/frontend/packages/client/src/components/CommunityProposalList.js
+++ b/frontend/packages/client/src/components/CommunityProposalList.js
@@ -37,7 +37,15 @@ const CommunityProposalList = ({
         <div className="has-text-weight-bold is-uppercase mb-5">Closed</div>
         <div className="is-flex is-flex-direction-column">
           {(proposalsList ?? []).map((pr, i) => (
-            <Link to={`/proposal/${pr.id}`} key={i}>
+            <Link
+              to={`/proposal/${pr.id}`}
+              key={i}
+              style={
+                ["closed", "cancelled"].includes(pr.computedStatus)
+                  ? { opacity: 0.6 }
+                  : {}
+              }
+            >
               <div
                 className="border-light rounded-sm mb-5 proposal-card transition-all"
                 key={i}

--- a/frontend/packages/client/src/components/CommunityProposalList.js
+++ b/frontend/packages/client/src/components/CommunityProposalList.js
@@ -2,7 +2,6 @@ import React from "react";
 import { Link } from "react-router-dom";
 import ProposalHeader from "./ProposalsList/ProposalHeader";
 import Loader from "./Loader";
-import { FilterValues } from "../const";
 
 const StyleForStatus = {
   closed: { opacity: 0.6 },
@@ -14,8 +13,8 @@ const CommunityProposalList = ({
   activeProposals = [],
   filterValue,
 } = {}) => {
-  // filter with active
-  if (filterValue === FilterValues["all"]) {
+  // filter with all value should show active and pending in one group and closed and cancelled in another group
+  if (filterValue === "all") {
     return (
       <>
         {initialLoading && <Loader fullHeight />}

--- a/frontend/packages/client/src/components/CommunityProposalList.js
+++ b/frontend/packages/client/src/components/CommunityProposalList.js
@@ -4,6 +4,10 @@ import ProposalHeader from "./ProposalsList/ProposalHeader";
 import Loader from "./Loader";
 import { FilterValues } from "../const";
 
+const StyleForStatus = {
+  closed: { opacity: 0.6 },
+  cancelled: { opacity: 0.6 },
+};
 const CommunityProposalList = ({
   proposalsList,
   initialLoading,
@@ -40,11 +44,7 @@ const CommunityProposalList = ({
             <Link
               to={`/proposal/${pr.id}`}
               key={i}
-              style={
-                ["closed", "cancelled"].includes(pr.computedStatus)
-                  ? { opacity: 0.6 }
-                  : {}
-              }
+              style={StyleForStatus[pr.computedStatus] ?? {}}
             >
               <div
                 className="border-light rounded-sm mb-5 proposal-card transition-all"
@@ -71,7 +71,11 @@ const CommunityProposalList = ({
       {initialLoading && <Loader fullHeight />}
       <div className="is-flex is-flex-direction-column">
         {(proposalsList ?? []).map((pr, i) => (
-          <Link to={`/proposal/${pr.id}`} key={i}>
+          <Link
+            to={`/proposal/${pr.id}`}
+            key={i}
+            style={StyleForStatus[pr.computedStatus] ?? {}}
+          >
             <div
               className="border-light rounded-sm mb-5 proposal-card transition-all"
               key={i}

--- a/frontend/packages/client/src/components/CommunityProposals.js
+++ b/frontend/packages/client/src/components/CommunityProposals.js
@@ -5,13 +5,12 @@ import { useCommunityProposalsWithVotes, useMediaQuery } from "../hooks";
 import { FilterValues } from "../const";
 import DropDownFilter from "./ProposalsList/DropdownFilter";
 import WrapperResponsive from "./WrapperResponsive";
-import omit from "lodash/omit";
 
 export default function CommunityProposals({ community = { id: 1 } }) {
   const notMobile = useMediaQuery();
 
-  const proposalFilterValues = Object.values(
-    omit(FilterValues, ["inprogress", "terminated"])
+  const proposalFilterValues = Object.values(FilterValues).filter(
+    (value) => "In Progress" !== value && "Terminated" !== value
   );
 
   const [filterValue, setFilterValues] = useState(FilterValues["all"]);

--- a/frontend/packages/client/src/components/CommunityProposals.js
+++ b/frontend/packages/client/src/components/CommunityProposals.js
@@ -5,7 +5,7 @@ import { useCommunityProposalsWithVotes, useMediaQuery } from "../hooks";
 import { FilterValues } from "../const";
 import DropDownFilter from "./ProposalsList/DropdownFilter";
 import WrapperResponsive from "./WrapperResponsive";
-import { omit } from "lodash";
+import omit from "lodash/omit";
 
 export default function CommunityProposals({ community = { id: 1 } }) {
   const notMobile = useMediaQuery();

--- a/frontend/packages/client/src/components/CommunityProposals.js
+++ b/frontend/packages/client/src/components/CommunityProposals.js
@@ -5,11 +5,14 @@ import { useCommunityProposalsWithVotes, useMediaQuery } from "../hooks";
 import { FilterValues } from "../const";
 import DropDownFilter from "./ProposalsList/DropdownFilter";
 import WrapperResponsive from "./WrapperResponsive";
+import { omit } from "lodash";
 
 export default function CommunityProposals({ community = { id: 1 } }) {
   const notMobile = useMediaQuery();
 
-  const proposalFilterValues = Object.values(FilterValues);
+  const proposalFilterValues = Object.values(
+    omit(FilterValues, ["inprogress", "terminated"])
+  );
 
   const [filterValue, setFilterValues] = useState(FilterValues["all"]);
 
@@ -19,7 +22,7 @@ export default function CommunityProposals({ community = { id: 1 } }) {
       count: 10,
       status:
         filterValue.toLocaleLowerCase() === "all"
-          ? FilterValues["closed"].toLocaleLowerCase()
+          ? FilterValues.terminated.toLocaleLowerCase()
           : filterValue.toLocaleLowerCase(),
     });
 
@@ -28,7 +31,7 @@ export default function CommunityProposals({ community = { id: 1 } }) {
     useCommunityProposalsWithVotes({
       communityId: community.id,
       count: 25,
-      status: "active",
+      status: "inprogress",
       scrollToFetchMore: false,
     });
 

--- a/frontend/packages/client/src/components/CommunityProposals.js
+++ b/frontend/packages/client/src/components/CommunityProposals.js
@@ -3,29 +3,34 @@ import { Link } from "react-router-dom";
 import CommunityProposalList from "./CommunityProposalList";
 import { useCommunityProposalsWithVotes, useMediaQuery } from "../hooks";
 import { FilterValues } from "../const";
-import DropDownFilter from "./ProposalsList/DropdownFilter";
+import DropDown from "./Dropdown";
 import WrapperResponsive from "./WrapperResponsive";
 
 export default function CommunityProposals({ community = { id: 1 } }) {
   const notMobile = useMediaQuery();
 
-  const proposalFilterValues = Object.values(FilterValues).filter(
-    (value) => "In Progress" !== value && "Terminated" !== value
-  );
+  const proposalFilterValues = Object.entries(FilterValues)
+    .filter(
+      ([, value]) =>
+        FilterValues.inProgress !== value && FilterValues.terminated !== value
+    )
+    .map(([key, value]) => ({ value: key, label: value }));
 
-  const [filterValue, setFilterValues] = useState(FilterValues["all"]);
+  const [filterValue, setFilterValues] = useState("all");
 
+  // When filter has all values two requests are made to the backend:
+  // one will bring all active and pending proposals: "inprogress"
+  // the other will bring all closed and cancelled proposals: "terminated"
+  // if status is any other value there will be only
+  // one request to bring proposals with the selected status
   const { data: proposals, loading: loadingProposals } =
     useCommunityProposalsWithVotes({
       communityId: community.id,
       count: 10,
-      status:
-        filterValue.toLocaleLowerCase() === "all"
-          ? FilterValues.terminated.toLocaleLowerCase()
-          : filterValue.toLocaleLowerCase(),
+      status: filterValue === "all" ? "terminated" : filterValue,
     });
 
-  // used to load active proposals without pulling data on scrolling
+  // used to load active and pending proposals without pulling data on scrolling
   const { data: activeProposals, loading: loadingActiveProposals } =
     useCommunityProposalsWithVotes({
       communityId: community.id,
@@ -40,7 +45,7 @@ export default function CommunityProposals({ community = { id: 1 } }) {
   }`;
 
   const initialLoading =
-    filterValue !== FilterValues["all"]
+    filterValue !== "all"
       ? loadingProposals && !proposals
       : loadingProposals &&
         !proposals &&
@@ -56,10 +61,12 @@ export default function CommunityProposals({ community = { id: 1 } }) {
             extraClasses="is-5"
             extraClassesMobile="mt-2 mb-5 is-8 pr-2"
           >
-            <DropDownFilter
-              value={filterValue}
-              filterValues={proposalFilterValues}
-              setFilterValues={setFilterValues}
+            <DropDown
+              defaultValue={{ value: "all", label: "All" }}
+              values={proposalFilterValues}
+              onSelectValue={(value) => {
+                setFilterValues(value);
+              }}
             />
           </WrapperResponsive>
           {!notMobile && (
@@ -110,8 +117,6 @@ export default function CommunityProposals({ community = { id: 1 } }) {
         <CommunityProposalList
           proposalsList={proposals}
           activeProposals={activeProposals}
-          proposalFilterValues={proposalFilterValues}
-          setFilterValues={setFilterValues}
           filterValue={filterValue}
           initialLoading={initialLoading}
         />

--- a/frontend/packages/client/src/components/Dropdown.js
+++ b/frontend/packages/client/src/components/Dropdown.js
@@ -10,6 +10,7 @@ const DropDown = forwardRef(
       disabled = false,
       label = "Select option",
       dropdownFull = true,
+      isRight = false,
     } = {},
     ref
   ) => {
@@ -41,9 +42,9 @@ const DropDown = forwardRef(
 
     return (
       <div
-        className={`dropdown is-right is-flex is-flex-grow-1${
-          isOpen ? " is-active" : ""
-        }`}
+        className={`dropdown ${
+          isRight ? "is-right " : ""
+        }is-flex is-flex-grow-1${isOpen ? " is-active" : ""}`}
         onBlur={closeOnBlur}
         aria-haspopup="true"
         aria-controls="dropdown-menu"

--- a/frontend/packages/client/src/const/index.js
+++ b/frontend/packages/client/src/const/index.js
@@ -7,4 +7,8 @@ export const FilterValues = {
   pending: "Pending",
   closed: "Closed",
   cancelled: "Cancelled",
+  // group of active and pending
+  inprogress: "In Progress",
+  // group of closed and canceled
+  terminated: "Terminated",
 };

--- a/frontend/packages/client/src/const/index.js
+++ b/frontend/packages/client/src/const/index.js
@@ -8,7 +8,7 @@ export const FilterValues = {
   closed: "Closed",
   cancelled: "Cancelled",
   // group of active and pending
-  inprogress: "In Progress",
+  inProgress: "In Progress",
   // group of closed and canceled
   terminated: "Terminated",
 };

--- a/frontend/packages/client/src/pages/Proposal.js
+++ b/frontend/packages/client/src/pages/Proposal.js
@@ -379,7 +379,7 @@ export default function ProposalPage() {
       <section className="section">
         <div className="container">
           <WrapperResponsive extraClasses="mb-6" extraClassesMobile="mb-3">
-            <Link to={`/community/${proposal.communityId}`}>
+            <Link to={`/community/${proposal.communityId}?tab=proposals`}>
               <span className="has-text-grey is-flex is-align-items-center back-button transition-all">
                 <ArrowLeft /> <span className="ml-3">Back</span>
               </span>


### PR DESCRIPTION
- Group active and pending proposals into one list 
- Group cancelled and closed proposals into one list 

<img width="1500" alt="Screen Shot 2022-05-23 at 16 08 37" src="https://user-images.githubusercontent.com/7526740/169889593-372ebe52-b2a5-4983-8efa-3d42b0b0dbaa.png">

