### PR TITLE
implemented FetchBalance on strategies, refactored controllers

### DIFF
--- a/backend/main/strategies/one_address_one_vote.go
+++ b/backend/main/strategies/one_address_one_vote.go
@@ -4,9 +4,35 @@ import (
 	"fmt"
 
 	"github.com/brudfyi/flow-voting-tool/main/models"
+	s "github.com/brudfyi/flow-voting-tool/main/shared"
+	"github.com/jackc/pgx/v4"
+	"github.com/rs/zerolog/log"
 )
 
 type OneAddressOneVote struct{}
+
+func (s *OneAddressOneVote) FetchBalance(db *s.Database, b *models.Balance, sc *s.SnapshotClient) (*models.Balance, error) {
+
+	if err := b.GetBalanceByAddressAndBlockHeight(db); err != nil && err.Error() != pgx.ErrNoRows.Error() {
+		log.Error().Err(err).Msg("error querying address b at blockheight")
+		return nil, err
+	}
+
+	if b.ID == "" {
+		err := b.FetchAddressBalanceAtBlockHeight(sc, b.Addr, b.BlockHeight)
+		if err != nil {
+			log.Error().Err(err).Msg("error fetching address b at blockheight.")
+			return nil, err
+		}
+
+		if err = b.CreateBalance(db); err != nil {
+			log.Error().Err(err).Msg("error saving b to DB")
+			return nil, err
+		}
+	}
+
+	return b, nil
+}
 
 func (s *OneAddressOneVote) TallyVotes(votes []*models.VoteWithBalance, proposalId int) (models.ProposalResults, error) {
 	var r models.ProposalResults
@@ -21,6 +47,18 @@ func (s *OneAddressOneVote) TallyVotes(votes []*models.VoteWithBalance, proposal
 	return r, nil
 }
 
+func (s *OneAddressOneVote) GetVoteWeightForBalance(vote *models.VoteWithBalance, proposal *models.Proposal) (float64, error) {
+	var weight float64
+	var ERROR error = fmt.Errorf("no address found")
+
+	if vote.Addr == "" {
+		return 0.00, ERROR
+	}
+	weight = 1.00
+
+	return weight, nil
+}
+
 func (s *OneAddressOneVote) GetVotes(votes []*models.VoteWithBalance, proposal *models.Proposal) ([]*models.VoteWithBalance, error) {
 
 	for _, vote := range votes {
@@ -32,16 +70,4 @@ func (s *OneAddressOneVote) GetVotes(votes []*models.VoteWithBalance, proposal *
 	}
 
 	return votes, nil
-}
-
-func (s *OneAddressOneVote) GetVoteWeightForBalance(vote *models.VoteWithBalance, proposal *models.Proposal) (float64, error) {
-	var weight float64
-	var ERROR error = fmt.Errorf("no address found")
-
-	if vote.Addr == "" {
-		return 0.00, ERROR
-	}
-	weight = 1.00
-
-	return weight, nil
 }

--- a/backend/main/strategies/token_weighted_default.go
+++ b/backend/main/strategies/token_weighted_default.go
@@ -5,9 +5,35 @@ import (
 	"math"
 
 	"github.com/brudfyi/flow-voting-tool/main/models"
+	s "github.com/brudfyi/flow-voting-tool/main/shared"
+	"github.com/jackc/pgx/v4"
+	"github.com/rs/zerolog/log"
 )
 
 type TokenWeightedDefault struct{}
+
+func (s *TokenWeightedDefault) FetchBalance(db *s.Database, b *models.Balance, sc *s.SnapshotClient) (*models.Balance, error) {
+
+	if err := b.GetBalanceByAddressAndBlockHeight(db); err != nil && err.Error() != pgx.ErrNoRows.Error() {
+		log.Error().Err(err).Msg("error querying address b at blockheight")
+		return nil, err
+	}
+
+	if b.ID == "" {
+		err := b.FetchAddressBalanceAtBlockHeight(sc, b.Addr, b.BlockHeight)
+		if err != nil {
+			log.Error().Err(err).Msg("error fetching address b at blockheight.")
+			return nil, err
+		}
+
+		if err = b.CreateBalance(db); err != nil {
+			log.Error().Err(err).Msg("error saving b to DB")
+			return nil, err
+		}
+	}
+
+	return b, nil
+}
 
 func (s *TokenWeightedDefault) TallyVotes(votes []*models.VoteWithBalance, proposalId int) (models.ProposalResults, error) {
 	var r models.ProposalResults
@@ -22,18 +48,6 @@ func (s *TokenWeightedDefault) TallyVotes(votes []*models.VoteWithBalance, propo
 	}
 
 	return r, nil
-}
-
-func (s *TokenWeightedDefault) GetVotes(votes []*models.VoteWithBalance, proposal *models.Proposal) ([]*models.VoteWithBalance, error) {
-
-	for _, vote := range votes {
-		weight, err := s.GetVoteWeightForBalance(vote, proposal)
-		if err != nil {
-			return nil, err
-		}
-		vote.Weight = &weight
-	}
-	return votes, nil
 }
 
 func (s *TokenWeightedDefault) GetVoteWeightForBalance(vote *models.VoteWithBalance, proposal *models.Proposal) (float64, error) {
@@ -59,4 +73,16 @@ func (s *TokenWeightedDefault) GetVoteWeightForBalance(vote *models.VoteWithBala
 	default:
 		return weight, ERROR
 	}
+}
+
+func (s *TokenWeightedDefault) GetVotes(votes []*models.VoteWithBalance, proposal *models.Proposal) ([]*models.VoteWithBalance, error) {
+
+	for _, vote := range votes {
+		weight, err := s.GetVoteWeightForBalance(vote, proposal)
+		if err != nil {
+			return nil, err
+		}
+		vote.Weight = &weight
+	}
+	return votes, nil
 }


### PR DESCRIPTION
In this PR I added code so that the strategies each implement a `FetchBalance` function

```FetchBalance(db *shared.Database, b *models.Balance, sc *shared.SnapshotClient) (*models.Balance, error)```

Before we were doing this logic in the controller. Now I have updated the code to call the same models function on struct `Balance` `GetBalanceByAddressAndBlockHeight`, I also moved the generic error and `if balance.ID == ""` block into the `FetchBalance`. This is beneficial as it reduces the length of the controller function `createVoteForProposal` and abstracts some logic away. 

However, currently, each strategy is implementing the exact same logic for Fetch Balance, and I can't imagine a case where they would be different. If they're not going to be unique for each strategy, we could move the logic from lines 14 to 35 into a reusable function inside `/shared` 

Additionally in other controller functions such as `getVotesForProposal` we are calling the models method on struct `Vote` `GetVotesForProposal` which already joins the balances to the votes in one sql query, I thought it best not to alter this.