### PR TITLE
created constructor for Proposal Results and new test case

### DIFF
--- a/backend/main/models/proposal_results.go
+++ b/backend/main/models/proposal_results.go
@@ -15,6 +15,20 @@ type ProposalResults struct {
 	Cid           *string            `json:"cid,omitempty"`
 }
 
+func NewProposalResults(id int) *ProposalResults {
+	p := new(ProposalResults)
+	p.Results = map[string]int{
+		"a": 0,
+		"b": 0,
+	}
+	p.Results_float = map[string]float64{
+		"a": 0.00,
+		"b": 0.00,
+	}
+	p.Proposal_id = id
+	return p
+}
+
 func (r *ProposalResults) GetLatestProposalResultsById(db *s.Database) error {
 	return pgxscan.Get(db.Context, db.Conn, r,
 		`

--- a/backend/main/strategies/one_address_one_vote.go
+++ b/backend/main/strategies/one_address_one_vote.go
@@ -9,16 +9,14 @@ import (
 type OneAddressOneVote struct{}
 
 func (s *OneAddressOneVote) TallyVotes(votes []*models.VoteWithBalance, proposalId int) (models.ProposalResults, error) {
-	var r models.ProposalResults
-	r.Results = map[string]int{}
-	r.Proposal_id = proposalId
+	r := models.NewProposalResults(proposalId)
 
 	//tally votes
 	for _, vote := range votes {
 		r.Results[vote.Choice]++
 	}
 
-	return r, nil
+	return *r, nil
 }
 
 func (s *OneAddressOneVote) GetVotes(votes []*models.VoteWithBalance, proposal *models.Proposal) ([]*models.VoteWithBalance, error) {

--- a/backend/main/strategies/staked_token_weighted_default.go
+++ b/backend/main/strategies/staked_token_weighted_default.go
@@ -11,17 +11,14 @@ type StakedTokenWeightedDefault struct{}
 
 // should handle and return error case here
 func (s *StakedTokenWeightedDefault) TallyVotes(votes []*models.VoteWithBalance, proposalId int) (models.ProposalResults, error) {
-	var r models.ProposalResults
-	r.Results = map[string]int{}
-	r.Results_float = map[string]float64{}
-	r.Proposal_id = proposalId
+	r := models.NewProposalResults(proposalId)
 
 	for _, vote := range votes {
 		r.Results[vote.Choice] += int(float64(*vote.StakingBalance) * math.Pow(10, -8))
 		r.Results_float[vote.Choice] += float64(*vote.StakingBalance) * math.Pow(10, -8)
 	}
 
-	return r, nil
+	return *r, nil
 }
 
 func (s *StakedTokenWeightedDefault) GetVotes(votes []*models.VoteWithBalance, proposal *models.Proposal) ([]*models.VoteWithBalance, error) {

--- a/backend/main/strategies/token_weighted_default.go
+++ b/backend/main/strategies/token_weighted_default.go
@@ -10,10 +10,7 @@ import (
 type TokenWeightedDefault struct{}
 
 func (s *TokenWeightedDefault) TallyVotes(votes []*models.VoteWithBalance, proposalId int) (models.ProposalResults, error) {
-	var r models.ProposalResults
-	r.Results = map[string]int{}
-	r.Results_float = map[string]float64{}
-	r.Proposal_id = proposalId
+	r := models.NewProposalResults(proposalId)
 
 	//tally votes
 	for _, vote := range votes {
@@ -21,7 +18,7 @@ func (s *TokenWeightedDefault) TallyVotes(votes []*models.VoteWithBalance, propo
 		r.Results_float[vote.Choice] += float64(*vote.PrimaryAccountBalance) * math.Pow(10, -8)
 	}
 
-	return r, nil
+	return *r, nil
 }
 
 func (s *TokenWeightedDefault) GetVotes(votes []*models.VoteWithBalance, proposal *models.Proposal) ([]*models.VoteWithBalance, error) {

--- a/backend/main/test_utils/vote_utils.go
+++ b/backend/main/test_utils/vote_utils.go
@@ -26,6 +26,11 @@ func (otu *OverflowTestUtils) GetVotesForProposalAPI(proposalId int) *httptest.R
 	return otu.ExecuteRequest(req)
 }
 
+func (otu *OverflowTestUtils) GetResultsForProposalAPI(proposalId int) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest("GET", "/proposals/"+strconv.Itoa(proposalId)+"/results", nil)
+	return otu.ExecuteRequest(req)
+}
+
 func (otu *OverflowTestUtils) GetVoteForProposalByAccountNameAPI(proposalId int, accountName string) *httptest.ResponseRecorder {
 	account, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", accountName))
 	addr := fmt.Sprintf("0x%s", account.Address().String())

--- a/backend/main/vote_test.go
+++ b/backend/main/vote_test.go
@@ -74,6 +74,18 @@ func TestGetVotes(t *testing.T) {
 
 		assert.Equal(t, voteCount, body.Count)
 	})
+
+	t.Run("Requesting results for a proposal where no votes exist should return default results object", func(t *testing.T) {
+		clearTable("votes")
+		defaultResults := models.NewProposalResults(proposalId)
+		response := otu.GetResultsForProposalAPI(proposalId)
+		CheckResponseCode(t, http.StatusOK, response.Code)
+
+		var body *models.ProposalResults
+		json.Unmarshal(response.Body.Bytes(), &body)
+
+		assert.Equal(t, defaultResults, body)
+	})
 }
 
 func TestCreateVote(t *testing.T) {


### PR DESCRIPTION
This is a bugfix for an issue that was not caught by out tests. We had no test that was hitting the endpoint ``http://localhost:5001/proposals/1/results``, this endpoint was returning an empty object, essentially null, in the case where a proposal with no votes was being fetched. 

A new constructor function has been added for ``ProposalResults`` struct and it is invoked inside ``TallyVotes``, the constructor sets default values for `Results_float` fields. 

A new test covering this scenario has been also been added. 