### PR TITLE
CAS-106: Add Endpoint for query community users by userType

### DIFF
--- a/backend/main/community_test.go
+++ b/backend/main/community_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -53,7 +52,6 @@ func TestCreateCommunity(t *testing.T) {
 	communityStruct := otu.GenerateCommunityStruct("account")
 	communityPayload := otu.GenerateCommunityPayload("account", communityStruct)
 	response := otu.CreateCommunityAPI(communityPayload)
-	fmt.Printf("%+v\n", response.Body)
 
 	// Check response code
 	checkResponseCode(t, http.StatusCreated, response.Code)
@@ -88,21 +86,13 @@ func TestCommunityAdminRoles(t *testing.T) {
 	response = otu.GetCommunityUsersAPI(community.ID)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	var p test_utils.PaginatedResponseWithUser
+	var p test_utils.PaginatedResponseWithUserType
 	json.Unmarshal(response.Body.Bytes(), &p)
 
-	//loop through response, validate user types for specific index
-	for i, u := range p.Data {
-		if i == 0 && u.Addr == test_utils.AdminAddr {
-			assert.Equal(t, "member", u.User_type)
-		}
-		if i == 1 && u.Addr == test_utils.AdminAddr {
-			assert.Equal(t, "author", u.User_type)
-		}
-		if i == 2 && u.Addr == test_utils.AdminAddr {
-			assert.Equal(t, "admin", u.User_type)
-		}
-	}
+	//Admin user has all possible roles
+	assert.Equal(t, true, p.Data[0].Is_admin)
+	assert.Equal(t, true, p.Data[0].Is_author)
+	assert.Equal(t, true, p.Data[0].Is_member)
 }
 
 func TestCommunityAuthorRoles(t *testing.T) {
@@ -131,18 +121,12 @@ func TestCommunityAuthorRoles(t *testing.T) {
 	response = otu.GetCommunityUsersAPI(community.ID)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
-	var p test_utils.PaginatedResponseWithUser
+	var p test_utils.PaginatedResponseWithUserType
 	json.Unmarshal(response.Body.Bytes(), &p)
 
-	//loop through response, validate user types for specific index
-	for i, u := range p.Data {
-		if i == 3 && u.Addr == test_utils.UserOneAddr {
-			assert.Equal(t, "author", u.User_type)
-		}
-		if i == 4 && u.Addr == test_utils.UserOneAddr {
-			assert.Equal(t, "member", u.User_type)
-		}
-	}
+	assert.Equal(t, false, p.Data[0].Is_admin)
+	assert.Equal(t, true, p.Data[0].Is_author)
+	assert.Equal(t, true, p.Data[0].Is_member)
 }
 
 func TestGetCommunityAPI(t *testing.T) {

--- a/backend/main/models/community_users.go
+++ b/backend/main/models/community_users.go
@@ -16,9 +16,9 @@ type CommunityUser struct {
 type CommunityUserType struct {
 	Community_id int    `json:"communityId" validate:"required"`
 	Addr         string `json:"addr" validate:"required"`
-	Is_admin     bool 	`json:"isAdmin" validate:"required"`
-	Is_author    bool 	`json:"isAuthor" validate:"required"`
-	Is_member    bool 	`json:"isMember" validate:"required"`
+	Is_admin     bool   `json:"isAdmin" validate:"required"`
+	Is_author    bool   `json:"isAuthor" validate:"required"`
+	Is_member    bool   `json:"isMember" validate:"required"`
 }
 
 type UserTypes []string
@@ -229,4 +229,13 @@ func GrantRolesToCommunityCreator(db *s.Database, addr string, communityId int) 
 func EnsureRoleForCommunity(db *s.Database, addr string, communityId int, userType string) error {
 	user := CommunityUser{Addr: addr, Community_id: communityId, User_type: userType}
 	return user.GetCommunityUser(db)
+}
+
+func EnsureValidRole(userType string) bool {
+	for _, t := range USER_TYPES {
+		if t == userType {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/main/server/app.go
+++ b/backend/main/server/app.go
@@ -1594,6 +1594,7 @@ func (a *App) handleGetCommunityUsersByType(w http.ResponseWriter, r *http.Reque
 	userType := vars["userType"]
 	if !models.EnsureValidRole(userType) {
 		respondWithError(w, http.StatusBadRequest, "Invalid userType")
+		return
 	}
 
 	count, _ := strconv.Atoi(r.FormValue("count"))
@@ -1606,7 +1607,7 @@ func (a *App) handleGetCommunityUsersByType(w http.ResponseWriter, r *http.Reque
 	}
 
 	users, totalRecords, err := models.GetUsersForCommunityByType(a.DB, communityId, start, count, userType)
-	fmt.Println(err)
+
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/backend/main/test_utils/community_utils.go
+++ b/backend/main/test_utils/community_utils.go
@@ -20,6 +20,14 @@ type PaginatedResponseWithUser struct {
 	Next         int                    `json:"next"`
 }
 
+type PaginatedResponseWithUserType struct {
+	Data         []models.CommunityUserType `json:"data"`
+	Start        int                        `json:"start"`
+	Count        int                        `json:"count"`
+	TotalRecords int                        `json:"totalRecords"`
+	Next         int                        `json:"next"`
+}
+
 var AdminAddr = "0xf8d6e0586b0a20c7"
 var UserOneAddr = "0x01cf0e2f2f715450"
 
@@ -132,6 +140,12 @@ func (otu *OverflowTestUtils) GetCommunityAPI(id int) *httptest.ResponseRecorder
 
 func (otu *OverflowTestUtils) GetCommunityUsersAPI(id int) *httptest.ResponseRecorder {
 	req, _ := http.NewRequest("GET", "/communities/"+strconv.Itoa(id)+"/users", nil)
+	response := otu.ExecuteRequest(req)
+	return response
+}
+
+func (otu *OverflowTestUtils) GetCommunityUsersAPIByType(id int, userType string) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest("GET", "/communities/"+strconv.Itoa(id)+"/users/type/"+userType, nil)
 	response := otu.ExecuteRequest(req)
 	return response
 }


### PR DESCRIPTION
**Ticket:** [CAS-106](https://linear.app/dappercollectives/issue/CAS-106/get-community-users-by-type-api-endpoint)

**Description:**

- Fixes test for `/communities/[communityId]/users` endpoint
- Removes unused code block in `TestCreateCommunityUsers`
- Adds endpoint `/communities/[communityId]/users/type/[userType]`
- Adds tests for above endpoint