### PR TITLE
fix(frontend): update role check for cancelling proposal

### DIFF
--- a/frontend/packages/client/src/hooks/useUserRoleOnCommunity.js
+++ b/frontend/packages/client/src/hooks/useUserRoleOnCommunity.js
@@ -36,7 +36,7 @@ export default function useUserRoleOnCommunity({
     return false;
   }
 
-  if (loading || roles.length === 0) {
+  if (loading || roles.length === 0 || !communityId) {
     return null;
   }
   if (pagination.next > 0) {
@@ -49,6 +49,8 @@ export default function useUserRoleOnCommunity({
         return datum.id.toString() === communityId.toString();
       })
       .map((community) => community?.membershipType) ?? [];
+
+  console.log(rolesInCommunity);
 
   return roles.every((role) => rolesInCommunity.includes(role));
 }

--- a/frontend/packages/client/src/hooks/useUserRoleOnCommunity.js
+++ b/frontend/packages/client/src/hooks/useUserRoleOnCommunity.js
@@ -50,7 +50,5 @@ export default function useUserRoleOnCommunity({
       })
       .map((community) => community?.membershipType) ?? [];
 
-  console.log(rolesInCommunity);
-
   return roles.every((role) => rolesInCommunity.includes(role));
 }

--- a/frontend/packages/client/src/pages/Proposal.js
+++ b/frontend/packages/client/src/pages/Proposal.js
@@ -12,7 +12,12 @@ import {
   Tablink,
 } from "components";
 import { CheckMark, ArrowLeft, Bin } from "components/Svg";
-import { useProposal, useVotingStrategies, useMediaQuery } from "hooks";
+import {
+  useProposal,
+  useVotingStrategies,
+  useMediaQuery,
+  useUserRoleOnCommunity,
+} from "hooks";
 import { useModalContext } from "contexts/NotificationModal";
 import { useWebContext } from "contexts/Web3";
 import { FilterValues } from "const";
@@ -20,8 +25,8 @@ import {
   CancelProposalModalConfirmation,
   ProposalStatus,
   VoteOptions,
-} from "../components/Proposal";
-import { getProposalType } from "../utils";
+} from "components/Proposal";
+import { getProposalType } from "utils";
 
 function useQueryParams() {
   const { search } = useLocation();
@@ -99,7 +104,12 @@ export default function ProposalPage() {
     error: strategiesError,
   } = useVotingStrategies();
 
-  const isAdmin = proposal && proposal?.creatorAddr === user?.addr;
+  // only authors on community can cancel the proposal
+  const canCancelProposal = useUserRoleOnCommunity({
+    addr: user?.addr,
+    communityId: proposal?.communityId,
+    roles: ["author"],
+  });
 
   const proposalStrategy =
     votingStrategies && !loadingStrategies && proposal && !loading
@@ -404,7 +414,7 @@ export default function ProposalPage() {
               proposal={proposal}
               className="is-flex is-align-items-center smaller-text"
             />
-            {showCancelButton && isAdmin && (
+            {showCancelButton && canCancelProposal && (
               <div className="is-flex is-align-items-center">
                 <button
                   className="button is-white has-text-grey small-text"


### PR DESCRIPTION
This PR fixes showing the cancel button on proposals for ex-authors (after the user has left the community: all roles are removed when a user leaves the community). 
Before the check as done by looking if the user address was the same as the one that created the proposal. 
Since now we have roles in the community, only community authors should be able to chancel them. If the creator left the community, the user will need to rejoin and get an author role to be able to cancel a proposal