### PR TITLE
style(frontend): remove scale on elements

### DIFF
--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -111,7 +111,6 @@ code
 		&.vote-button:hover
 			color: black
 			border: 1px solid rgba(0, 0, 0, 0.4) !important
-			transform: scale(1.01)
 .button.is-disabled
 	pointer-events: none
 	opacity: 0.5
@@ -248,8 +247,6 @@ hr
 	border-bottom-width: 0px
 	&.tab-community
 		border-bottom-width: 2px
-		&:hover
-			transform: scale(1.04)
 
 .tabs li.is-active a
 	border-bottom-color: $yellow
@@ -431,18 +428,16 @@ span[data-tooltip]
 .wallet-connect.button.is-primary:hover, .button-vote:hover
 	border-color: rgba(0, 0, 0, 0.4) !important
 	border-width: 1px !important
-	transform: scale(1.01)
+
 .wallet-connect.button.is-primary
 	color: #000000 !important
 
 .community-card:hover, .proposal-card:hover
 	border-color: rgba(0, 0, 0, 0.4)
 	border-width: 1px
-	transform: scale(1.01)
 
 .tab-link:hover
 	padding-left: 0.3rem
-	transform: scale(1.04)
 
 .back-button:hover
 	margin-left: -0.25rem
@@ -453,7 +448,6 @@ span[data-tooltip]
 	border-width: 1px
 
 .navbar-item-hover:hover
-	transform: scale(1.1)
 	color: rgba(0, 0, 0, 0.7)
 
 .button:hover

--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -436,9 +436,6 @@ span[data-tooltip]
 	border-color: rgba(0, 0, 0, 0.4)
 	border-width: 1px
 
-.tab-link:hover
-	padding-left: 0.3rem
-
 .back-button:hover
 	margin-left: -0.25rem
 	color: rgba(0, 0, 0, 0.7) !important

--- a/frontend/packages/client/src/components/Tablink.js
+++ b/frontend/packages/client/src/components/Tablink.js
@@ -41,12 +41,10 @@ const Tablink = ({
     <>{linkText}</>
   );
 
-  const animateClasses = animateHover ? " tab-link transition-all" : "";
-
   return (
     <Link to={linkUrl} className={textClass}>
       <div
-        className={`is-flex is-align-items-center is-justify-content-left ${animateClasses}`}
+        className={`is-flex is-align-items-center is-justify-content-left`}
       >
         {link}
       </div>

--- a/frontend/packages/client/src/components/Tablink.js
+++ b/frontend/packages/client/src/components/Tablink.js
@@ -8,7 +8,6 @@ const Tablink = ({
   isActive,
   onlyLink,
   onClick = () => {},
-  animateHover = false,
   className = "",
 }) => {
   const textClass = `${className} ${
@@ -43,9 +42,7 @@ const Tablink = ({
 
   return (
     <Link to={linkUrl} className={textClass}>
-      <div
-        className={`is-flex is-align-items-center is-justify-content-left`}
-      >
+      <div className={`is-flex is-align-items-center is-justify-content-left`}>
         {link}
       </div>
     </Link>


### PR DESCRIPTION
When hovering over items like Community Card (homepage), Back button, proposal card, etc the elements have a zoom effect. This PR removes that effect