### PR TITLE
fix(frontend): fix user removal from community

### DIFF
--- a/frontend/packages/client/src/hooks/useCommunityUsers.js
+++ b/frontend/packages/client/src/hooks/useCommunityUsers.js
@@ -126,6 +126,12 @@ export default function useCommunityUsers({
     dispatch({ type: 'RESET_RESULTS' });
   };
 
+  // clears all results and pulls again
+  const reFetch = async () => {
+    resetResults();
+    await getCommunityUsers();
+  };
+
   useEffect(() => {
     getCommunityUsers();
   }, [getCommunityUsers]);
@@ -137,5 +143,6 @@ export default function useCommunityUsers({
     getCommunityUsers,
     fetchMore,
     resetResults,
+    reFetch,
   };
 }

--- a/frontend/packages/client/src/hooks/useCommunityUsers.js
+++ b/frontend/packages/client/src/hooks/useCommunityUsers.js
@@ -40,9 +40,9 @@ export default function useCommunityUsers({
     dispatch({ type: 'PROCESSING' });
     const url = `${
       process.env.REACT_APP_BACK_END_SERVER_API
-    }/communities/${communityId}/users?count=${state.pagination.count}&start=${
+    }/communities/${communityId}/users${type ? `/type/${type}` : ''}?count=${
       state.pagination.start
-    }${type ? `&userType=${type}` : ''}`;
+    }&start=${state.pagination.start}`;
     try {
       const response = await fetch(url);
       const users = await checkResponse(response);
@@ -61,9 +61,9 @@ export default function useCommunityUsers({
     dispatch({ type: 'PROCESSING' });
     const url = `${
       process.env.REACT_APP_BACK_END_SERVER_API
-    }/communities/${communityId}/users?count=${count}&start=${start}${
-      type ? `&userType=${type}` : ''
-    }`;
+    }/communities/${communityId}/users${
+      type ? `/type/${type}` : ''
+    }?count=${count}&start=${start}`;
     try {
       const response = await fetch(url);
       const users = await checkResponse(response);

--- a/frontend/packages/client/src/pages/Community.js
+++ b/frontend/packages/client/src/pages/Community.js
@@ -153,9 +153,18 @@ export default function Community() {
     roles: ['admin'],
   });
 
-  const { data: admins } = useCommunityUsers({ communityId, type: 'admin' });
-  const { data: authors } = useCommunityUsers({ communityId, type: 'author' });
+  const { data: admins, reFetch: reFectAdmins } = useCommunityUsers({
+    communityId,
+    type: 'admin',
+  });
 
+  const { data: authors, reFetch: reFectAuthors } = useCommunityUsers({
+    communityId,
+    type: 'author',
+  });
+
+  console.log(admins);
+  console.log(authors);
   const { data: strategies } = useVotingStrategies();
 
   const {
@@ -186,6 +195,17 @@ export default function Community() {
   };
 
   const notMobile = useMediaQuery();
+
+  const onUserLeaveCommunity = async () => {
+    // if current user leaving community is admin or author
+    // trigger update on admin and author list
+    if (authors?.find((author) => author.addr === addr)) {
+      await reFectAuthors();
+    }
+    if (admins?.find((admin) => admin.addr === addr)) {
+      await reFectAdmins();
+    }
+  };
 
   if (error) {
     // modal will show error message
@@ -260,6 +280,7 @@ export default function Community() {
             <JoinCommunityButton
               communityId={communityId}
               setTotalMembers={setTotalMembers}
+              onLeaveCommunity={onUserLeaveCommunity}
             />
           </div>
         </div>


### PR DESCRIPTION
- When an admin or author user leaves a community by clicking the leave button. User loses all roles, if user happen to be admin or author these lists are not being updated and the user is still shown in the list as admin, author or both. 

<img width="434" alt="Screen Shot 2022-06-26 at 22 11 58" src="https://user-images.githubusercontent.com/7526740/175842824-38edc731-18b1-4bd8-87b2-6cd1c1c8a267.png">

- Also icon for admins do not get updated and still shows the admin icon: 
<img width="251" alt="Screen Shot 2022-06-26 at 22 15 24" src="https://user-images.githubusercontent.com/7526740/175842966-135c5f67-ff1d-4847-879a-9162e8204794.png">

This PR adds a callback function that when user leaves the community and the user has an admin and/or author role, it triggers an update on hooks for listing admins and/or authors 