### PR TITLE
fix: make proposal description apear under stepper

### DIFF
--- a/frontend/packages/client/src/components/StepByStep/index.js
+++ b/frontend/packages/client/src/components/StepByStep/index.js
@@ -222,7 +222,7 @@ function StepByStep({
         {/* left panel mobile */}
         <div
           className="is-hidden-tablet has-background-white-ter p-4"
-          style={{ position: 'fixed', minWidth: '100%', zIndex: 1 }}
+          style={{ position: 'fixed', minWidth: '100%', zIndex: 2 }}
         >
           <div className="is-flex is-justify-content-space-between is-align-items-center">
             <div style={{ minHeight: 24 }}>


### PR DESCRIPTION
Editor container is zindex=1, so stepper needs to be higher: 

<img width="448" alt="Screen Shot 2022-06-27 at 14 31 03" src="https://user-images.githubusercontent.com/7526740/176000711-3ebca32d-b09f-465b-b892-dd45aafc5f30.png">

<img width="347" alt="Screen Shot 2022-06-27 at 14 21 48" src="https://user-images.githubusercontent.com/7526740/176000535-d263ad2b-6d79-439f-aa17-2df23ec926e6.png">


