### PR TITLE
fix(frontend): fix autofocus on author editor step

### DIFF
--- a/frontend/packages/client/src/components/Community/CommunityEditorDetails.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorDetails.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Bin, ValidCheckMark, InvalidCheckMark } from 'components/Svg';
 import { WrapperResponsive, Loader, AddButton } from 'components';
 import { useCommunityUsers } from 'hooks';
@@ -9,15 +9,6 @@ import useFlowAddrValidator, {
   validateAddrInList,
 } from './hooks/useFlowAddrValidator';
 import FadeIn from 'components/FadeIn';
-
-const determineAutoFocus = (listLength, index, addr, autoFocusOnLoad) => {
-  return (
-    // fist element of list depends on configuration (autoFocusOnLoad)
-    (listLength === 1 && addr === '' && autoFocusOnLoad) ||
-    // new elements on list will be autofocus by default
-    (listLength === index + 1 && addr === '' && index !== 0)
-  );
-};
 
 export const CommunityUsersForm = ({
   title,
@@ -35,6 +26,14 @@ export const CommunityUsersForm = ({
   autoFocusOnLoad = false,
 } = {}) => {
   const canDeleteAddress = addrList.length > 1;
+
+  const refOnFirstInput = useRef();
+
+  useEffect(() => {
+    if (refOnFirstInput.current) {
+      refOnFirstInput.current.focus();
+    }
+  }, [refOnFirstInput]);
   return (
     <div className="border-light rounded-lg columns is-flex-direction-column is-mobile m-0 p-6 mb-6 p-4-mobile mb-4-mobile">
       <div className="columns flex-1">
@@ -70,12 +69,6 @@ export const CommunityUsersForm = ({
                   isInvalid ? 'form-error-input-border' : ''
                 }`
               : 'pr-6';
-            const hasAutoFocus = determineAutoFocus(
-              addrList.length,
-              index,
-              addr,
-              autoFocusOnLoad
-            );
             return (
               <div
                 key={`index-${index}`}
@@ -90,12 +83,17 @@ export const CommunityUsersForm = ({
                   onChange={(event) =>
                     onAddressChange(index, event.target.value)
                   }
-                  autoFocus={hasAutoFocus}
+                  autoFocus={addrList.length === index + 1 && addr === ''}
                   disabled={fromServer ?? false}
                   style={{
                     width: '100%',
                     ...(isInvalid ? {} : undefined),
                   }}
+                  ref={
+                    addrList.length === 1 && addr === '' && autoFocusOnLoad
+                      ? refOnFirstInput
+                      : undefined
+                  }
                 />
                 <div
                   style={{

--- a/frontend/packages/client/src/components/Community/CommunityEditorDetails.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorDetails.js
@@ -10,6 +10,15 @@ import useFlowAddrValidator, {
 } from './hooks/useFlowAddrValidator';
 import FadeIn from 'components/FadeIn';
 
+const determineAutoFocus = (listLength, index, addr, autoFocusOnLoad) => {
+  return (
+    // fist element of list depends on configuration (autoFocusOnLoad)
+    (listLength === 1 && addr === '' && autoFocusOnLoad) ||
+    // new elements on list will be autofocus by default
+    (listLength === index + 1 && addr === '' && index !== 0)
+  );
+};
+
 export const CommunityUsersForm = ({
   title,
   description,
@@ -23,6 +32,7 @@ export const CommunityUsersForm = ({
   submitComponent,
   validateEachAddress = false,
   onClearField = () => {},
+  autoFocusOnLoad = false,
 } = {}) => {
   const canDeleteAddress = addrList.length > 1;
   return (
@@ -60,6 +70,12 @@ export const CommunityUsersForm = ({
                   isInvalid ? 'form-error-input-border' : ''
                 }`
               : 'pr-6';
+            const hasAutoFocus = determineAutoFocus(
+              addrList.length,
+              index,
+              addr,
+              autoFocusOnLoad
+            );
             return (
               <div
                 key={`index-${index}`}
@@ -74,7 +90,7 @@ export const CommunityUsersForm = ({
                   onChange={(event) =>
                     onAddressChange(index, event.target.value)
                   }
-                  autoFocus={addrList.length === index + 1 && addr === ''}
+                  autoFocus={hasAutoFocus}
                   disabled={fromServer ?? false}
                   style={{
                     width: '100%',

--- a/frontend/packages/client/src/components/CommunityCreate/StepTwo.js
+++ b/frontend/packages/client/src/components/CommunityCreate/StepTwo.js
@@ -141,6 +141,7 @@ export default function StepTwo({
         label="Domain name or wallet address"
         validateEachAddress
         onClearField={(index) => onAdminAddressChange(index, '')}
+        autoFocusOnLoad={true}
       />
       <CommunityUsersForm
         title="Authors"
@@ -153,6 +154,7 @@ export default function StepTwo({
         label="Domain name or wallet address"
         validateEachAddress
         onClearField={(index) => onAuthorAddressChange(index, '')}
+        autoFocusOnLoad={false}
       />
       <div className="columns mb-5">
         <div className="column is-12">


### PR DESCRIPTION
On community creation workflow, second step, autofocus is applied to last element on authors list. It should be applied to admins since it's the first input to complete that appears: 
<img width="489" alt="Screen Shot 2022-06-28 at 11 09 15" src="https://user-images.githubusercontent.com/7526740/176199875-3e5db07d-f343-4291-a2c7-b84f1c4fc5c4.png">

Fixed: 
<img width="494" alt="Screen Shot 2022-06-28 at 11 00 38" src="https://user-images.githubusercontent.com/7526740/176200256-ea6d88a0-c578-4dc5-82c4-b60661cf01ef.png">

Next new inputs will have autofocus as the are added on the page
