### PR TITLE
fix(frontend): remove yellow border on button hover

### DIFF
--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -29,8 +29,6 @@ $button-background-color: transparent
 $button-border-color: black
 $button-color: black
 $button-border-width: 1px
-$button-hover-color: $yellow
-$button-hover-border-color: $yellow
 $title-size: 2.5rem
 $progress-bar-background-color: $yellow
 $input-color: black


### PR DESCRIPTION
Now it defaults to: `border-color: hsl(0deg, 0%, 71%);` from bulma config

https://user-images.githubusercontent.com/7526740/176703023-7393a415-a488-4cb1-9130-cdb0684b87c6.mov

