### PR TITLE
bugfix cas-168 update does not overwrite nil fields

### DIFF
--- a/backend/main/models/community.go
+++ b/backend/main/models/community.go
@@ -192,11 +192,21 @@ func (c *Community) UpdateCommunity(db *s.Database, p *UpdateCommunityRequestPay
 		db.Context,
 		`
 	UPDATE communities
-	SET name = $1, body = $2, logo = $3, strategies = $4, strategy = $5, 
-		banner_img_url = $6, website_url = $7, twitter_url = $8, github_url = $9,
-		discord_url = $10, instagram_url = $11, proposal_validation = $12, 
-		proposal_threshold = $13, category = $14,
-		terms_and_conditions_url = $15
+	SET name = COALESCE($1, name), 
+	body = COALESCE($2, body), 
+	logo = COALESCE($3, logo), 
+	strategies = COALESCE($4, strategies), 
+	strategy = COALESCE($5, strategy),
+	banner_img_url = COALESCE($6, banner_img_url),
+	website_url = COALESCE($7, website_url),
+	twitter_url = COALESCE($8, twitter_url),
+	github_url = COALESCE($9, github_url),
+	discord_url = COALESCE($10, discord_url),
+	instagram_url = COALESCE($11, instagram_url),
+	proposal_validation = COALESCE($12, proposal_validation),
+	proposal_threshold = COALESCE($13, proposal_threshold),
+	category = COALESCE($14, category),
+	terms_and_conditions_url = COALESCE($15, terms_and_conditions_url)
 	WHERE id = $16
 	`,
 		p.Name,

--- a/backend/main/models/community.go
+++ b/backend/main/models/community.go
@@ -19,7 +19,7 @@ type Community struct {
 	Name                     string      `json:"name,omitempty"`
 	Category                 *string     `json:"category,omitempty"              validate:"required"`
 	Logo                     *string     `json:"logo,omitempty"`
-	Body                     *string     `json:"body,omitempty"                  validate:"required"`
+	Body                     *string     `json:"body,omitempty"`
 	Strategies               *[]Strategy `json:"strategies,omitempty"`
 	Strategy                 *string     `json:"strategy,omitempty"`
 	Banner_img_url           *string     `json:"bannerImgUrl,omitempty"`

--- a/backend/main/server/app.go
+++ b/backend/main/server/app.go
@@ -1082,13 +1082,14 @@ func (a *App) updateCommunity(w http.ResponseWriter, r *http.Request) {
 
 	defer r.Body.Close()
 
-	// Fetch community
 	var c = models.Community{ID: id}
 	if err := c.GetCommunity(a.DB); err != nil {
 		log.Error().Err(err)
 		respondWithError(w, http.StatusBadRequest, fmt.Sprintf("Invalid request: no community with ID %d", id))
 		return
 	}
+
+	fmt.Printf("community before update: %+v\n", c)
 
 	payload.Name = &c.Name
 
@@ -1126,6 +1127,8 @@ func (a *App) updateCommunity(w http.ResponseWriter, r *http.Request) {
 		respondWithError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+
+	fmt.Printf("community after update: %+v\n", c)
 
 	respondWithJSON(w, http.StatusOK, c)
 }

--- a/backend/main/server/app.go
+++ b/backend/main/server/app.go
@@ -1089,8 +1089,6 @@ func (a *App) updateCommunity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Printf("community before update: %+v\n", c)
-
 	payload.Name = &c.Name
 
 	// validate is commuity creator
@@ -1127,8 +1125,6 @@ func (a *App) updateCommunity(w http.ResponseWriter, r *http.Request) {
 		respondWithError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-
-	fmt.Printf("community after update: %+v\n", c)
 
 	respondWithJSON(w, http.StatusOK, c)
 }

--- a/backend/main/server/app.go
+++ b/backend/main/server/app.go
@@ -1089,8 +1089,6 @@ func (a *App) updateCommunity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	payload.Name = &c.Name
-
 	// validate is commuity creator
 	// TODO: update to validating address is admin
 	if err := c.CanUpdateCommunity(a.DB, payload.Signing_addr); err != nil {


### PR DESCRIPTION
the avatar, or `Logo` field was being overwritten with `nil` on update if a value was not sent in the payload. This has been fixed by using the `COALESCE` keyword in the sql `UpdateCommunity` models function