### PR TITLE
cas-107 / 156 Increase time before proposals can start

### DIFF
--- a/backend/main/models/proposal.go
+++ b/backend/main/models/proposal.go
@@ -171,29 +171,6 @@ func (p *Proposal) IsLive() bool {
 	return now.After(p.Start_time) && now.Before(p.End_time)
 }
 
-func (p *Proposal) SetStatus() string {
-	var active = "active"
-	var pending = "pending"
-
-	pastGracePeriod := p.CheckGracePeriod()
-
-	if pastGracePeriod {
-		p.Status = &active
-	} else {
-		p.Status = &pending
-	}
-
-	return *p.Status
-}
-
-func (p *Proposal) CheckGracePeriod() bool {
-	oneHourSinceCreated := p.Start_time.Add(time.Hour)
-	if time.Now().UTC().After(oneHourSinceCreated) {
-		return true
-	}
-	return false
-}
-
 // Validations
 
 // Returns an error if the account's balance is insufficient to cast

--- a/backend/main/models/proposal.go
+++ b/backend/main/models/proposal.go
@@ -111,13 +111,41 @@ func (p *Proposal) GetProposalById(db *s.Database) error {
 }
 
 func (p *Proposal) CreateProposal(db *s.Database) error {
-	// signaturesJSON := json.Marshal(p.Composite_signatures)
 	err := db.Conn.QueryRow(db.Context,
 		`
-	INSERT INTO proposals(community_id, name, choices, strategy, min_balance, max_weight, creator_addr, start_time, end_time, status, body, block_height, cid, composite_signatures)
+	INSERT INTO proposals(community_id, 
+	name, 
+	choices, 
+	strategy, 
+	min_balance, 
+	max_weight, 
+	creator_addr, 
+	start_time, 
+	end_time, 
+	status, 
+	body, 
+	block_height, 
+	cid, 
+	composite_signatures
+	)
 	VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 	RETURNING id, created_at
-	`, p.Community_id, p.Name, p.Choices, p.Strategy, p.Min_balance, p.Max_weight, p.Creator_addr, p.Start_time, p.End_time, p.Status, p.Body, p.Block_height, p.Cid, p.Composite_signatures).Scan(&p.ID, &p.Created_at)
+	`,
+		p.Community_id,
+		p.Name,
+		p.Choices,
+		p.Strategy,
+		p.Min_balance,
+		p.Max_weight,
+		p.Creator_addr,
+		p.Start_time,
+		p.End_time,
+		p.Status,
+		p.Body,
+		p.Block_height,
+		p.Cid,
+		p.Composite_signatures,
+	).Scan(&p.ID, &p.Created_at)
 
 	return err // will be nil unless something went wrong
 }
@@ -141,6 +169,29 @@ func (p *Proposal) UpdateProposal(db *s.Database) error {
 func (p *Proposal) IsLive() bool {
 	now := time.Now().UTC()
 	return now.After(p.Start_time) && now.Before(p.End_time)
+}
+
+func (p *Proposal) SetStatus() string {
+	var active = "active"
+	var pending = "pending"
+
+	pastGracePeriod := p.CheckGracePeriod()
+
+	if pastGracePeriod {
+		p.Status = &active
+	} else {
+		p.Status = &pending
+	}
+
+	return *p.Status
+}
+
+func (p *Proposal) CheckGracePeriod() bool {
+	oneHourSinceCreated := p.Start_time.Add(time.Hour)
+	if time.Now().UTC().After(oneHourSinceCreated) {
+		return true
+	}
+	return false
 }
 
 // Validations

--- a/backend/main/proposal_test.go
+++ b/backend/main/proposal_test.go
@@ -166,7 +166,7 @@ func TestUpdateProposal(t *testing.T) {
 		var created models.Proposal
 		json.Unmarshal(response.Body.Bytes(), &created)
 
-		assert.Equal(t, "active", *created.Computed_status)
+		assert.Equal(t, "pending", *created.Computed_status)
 
 		cancelPayload := otu.GenerateCancelProposalStruct(authorName, communityId)
 		response = otu.UpdateProposalAPI(p.ID, cancelPayload)

--- a/backend/main/server/app.go
+++ b/backend/main/server/app.go
@@ -827,7 +827,7 @@ func (a *App) createProposal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if os.Getenv("APP_ENV") != "PRODUCTION" {
+	if os.Getenv("APP_ENV") == "PRODUCTION" {
 		if strategy.Contract.Name != nil && p.Start_time.Before(time.Now().Add(time.Hour)) {
 			p.Start_time = time.Now().Add(time.Hour)
 		}

--- a/backend/main/server/app.go
+++ b/backend/main/server/app.go
@@ -827,8 +827,10 @@ func (a *App) createProposal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if strategy.Contract.Name != nil && p.Start_time.Before(time.Now().Add(time.Hour)) {
-		p.Start_time = time.Now().Add(time.Hour)
+	if os.Getenv("APP_ENV") != "PRODUCTION" {
+		if strategy.Contract.Name != nil && p.Start_time.Before(time.Now().Add(time.Hour)) {
+			p.Start_time = time.Now().Add(time.Hour)
+		}
 	}
 
 	// create proposal

--- a/backend/main/server/app.go
+++ b/backend/main/server/app.go
@@ -828,8 +828,8 @@ func (a *App) createProposal(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if os.Getenv("APP_ENV") == "PRODUCTION" {
-		if strategy.Contract.Name != nil && p.Start_time.Before(time.Now().Add(time.Hour)) {
-			p.Start_time = time.Now().Add(time.Hour)
+		if strategy.Contract.Name != nil && p.Start_time.Before(time.Now().UTC().Add(time.Hour)) {
+			p.Start_time = time.Now().UTC().Add(time.Hour)
 		}
 	}
 


### PR DESCRIPTION
In Production environment only we need to increase the time a proposal can go live to 1 hour after the current time for proposals. 

This should be reflected in the frontend UI and also validated on the backend as well. The reason for this change is because the snapshotter tool will need time to run and capture the chain so we know which accounts had the correct balance at the time the proposal was created:

• Adds SetStatus method on `createProposal` and `getProposal` controllers
• Checks if grace period has passed, only if strategy has a contract and environment is prod. Grace period is one hour