### PR TITLE
Rich/cas 129

### DIFF
--- a/backend/main/cadence/transactions/transfer_nft.cdc
+++ b/backend/main/cadence/transactions/transfer_nft.cdc
@@ -1,0 +1,45 @@
+import NonFungibleToken from 0xf8d6e0586b0a20c7
+import ExampleNFT from 0xf8d6e0586b0a20c7
+
+/// This transaction is for transferring and NFT from
+/// one account to another
+
+transaction(recipient: Address, withdrawID: UInt64) {
+
+    /// Reference to the withdrawer's collection
+    let withdrawRef: &ExampleNFT.Collection
+
+    /// Reference of the collection to deposit the NFT to
+    let depositRef: &{NonFungibleToken.CollectionPublic}
+
+    prepare(signer: AuthAccount) {
+        // borrow a reference to the signer's NFT collection
+        self.withdrawRef = signer
+            .borrow<&ExampleNFT.Collection>(from: ExampleNFT.CollectionStoragePath)
+            ?? panic("Account does not store an object at the specified path")
+
+        // get the recipients public account object
+        let recipient = getAccount(recipient)
+
+        // borrow a public reference to the receivers collection
+        self.depositRef = recipient
+            .getCapability(ExampleNFT.CollectionPublicPath)
+            .borrow<&{NonFungibleToken.CollectionPublic}>()
+            ?? panic("Could not borrow a reference to the receiver's collection")
+
+    }
+
+    execute {
+
+        // withdraw the NFT from the owner's collection
+        let nft <- self.withdrawRef.withdraw(withdrawID: withdrawID)
+
+        // Deposit the NFT in the recipient's collection
+        self.depositRef.deposit(token: <-nft)
+    }
+
+    post {
+        !self.withdrawRef.getIDs().contains(withdrawID): "Original owner should not have the NFT anymore"
+        self.depositRef.getIDs().contains(withdrawID): "The reciever should now own the NFT"
+    }
+}

--- a/backend/main/server/app.go
+++ b/backend/main/server/app.go
@@ -997,7 +997,6 @@ func (a *App) createCommunity(w http.ResponseWriter, r *http.Request) {
 
 	c = payload.Community
 
-	// validate timestamp of request/message
 	if err := a.validateTimestamp(c.Timestamp, 60); err != nil {
 		respondWithError(w, http.StatusForbidden, err.Error())
 		return

--- a/backend/main/strategies/balance_of_nfts.go
+++ b/backend/main/strategies/balance_of_nfts.go
@@ -73,7 +73,6 @@ func (b *BalanceOfNfts) TallyVotes(
 ) (models.ProposalResults, error) {
 
 	for _, v := range votes {
-		//print the length of v.NFTs
 		nftCount := len(v.NFTs)
 		r.Results_float[v.Choice] += float64(nftCount) * math.Pow(10, -8)
 	}

--- a/backend/main/strategies_test.go
+++ b/backend/main/strategies_test.go
@@ -164,7 +164,25 @@ func TestBalanceOfNFTsStrategy(t *testing.T) {
 	})
 
 	t.Run("Attempt to cheat the NFT strategy", func(t *testing.T) {
-		otu.TransferNFT("user1", "user2", 1)
+		votes, err := otu.GenerateListOfVotesWithNFTs(proposalId, 5, contract)
+		if err != nil {
+			t.Error(err)
+		}
+
+		proposalWithChoices := models.NewProposalResults(proposalId, choices)
+		_results := otu.TallyResultsForBalanceOfNfts(votes, proposalWithChoices)
+
+		response := otu.GetProposalResultsAPI(proposalId)
+		CheckResponseCode(t, http.StatusOK, response.Code)
+
+		var results models.ProposalResults
+		json.Unmarshal(response.Body.Bytes(), &results)
+
+		assert.Equal(t, _results.Proposal_id, results.Proposal_id)
+		assert.Equal(t, _results.Results_float["a"], results.Results_float["a"])
+		assert.Equal(t, _results.Results_float["b"], results.Results_float["b"])
+
+		otu.TransferNFT("user2", "user6", 1)
 	})
 }
 

--- a/backend/main/strategies_test.go
+++ b/backend/main/strategies_test.go
@@ -162,6 +162,10 @@ func TestBalanceOfNFTsStrategy(t *testing.T) {
 		expectedWeight := float64(1.00)
 		assert.Equal(t, expectedWeight, *vote.Weight)
 	})
+
+	t.Run("Attempt to cheat the NFT strategy", func(t *testing.T) {
+		otu.TransferNFT("user1", "user2", 1)
+	})
 }
 
 /* Staked Token Weighted Default */

--- a/backend/main/test_utils/strategy_utils.go
+++ b/backend/main/test_utils/strategy_utils.go
@@ -162,6 +162,33 @@ func (otu *OverflowTestUtils) GenerateListOfVotesWithNFTs(
 	return &votes, nil
 }
 
+func (otu *OverflowTestUtils) GenerateSingleVoteWithNFT(
+	proposalId int,
+	accountNumber int,
+	contract *shared.Contract,
+) (*VoteWithBalance, error) {
+	addr := otu.ResolveUser(1)
+	randomNumber := rand.Intn(2)
+	choices := []string{"a", "b"}
+	choice := choices[randomNumber]
+	v := models.Vote{
+		Proposal_id: proposalId, Addr: addr, Choice: choice,
+	}
+
+	nftIds, err := otu.Adapter.GetNFTIds(addr, contract)
+	if err != nil {
+		return nil, err
+	}
+
+	vote := otu.CreateNFTVote(v, nftIds, contract)
+	balance := 100000000 * (accountNumber)
+	vote.Primary_account_balance = uint64(balance)
+	vote.Staking_balance = uint64(balance * 5)
+	vote.Block_height = uint64(0)
+
+	return &vote, nil
+}
+
 func (otu *OverflowTestUtils) CreateNFTVote(v models.Vote, ids []interface{}, contract *shared.Contract) VoteWithBalance {
 	nfts := []models.NFT{}
 

--- a/backend/main/test_utils/strategy_utils.go
+++ b/backend/main/test_utils/strategy_utils.go
@@ -160,13 +160,19 @@ func (otu *OverflowTestUtils) CreateNFTVote(v models.Vote, ids []interface{}, co
 	return vote
 }
 
+func (otu *OverflowTestUtils) SetupAccountForNFTs(account string) {
+	otu.O.TransactionFromFile("setup_account").
+		SignProposeAndPayAs(account).
+		RunPrintEventsFull()
+}
+
 func (otu *OverflowTestUtils) CreateNFTCollection(account string) {
 	otu.O.TransactionFromFile("create_collection").
 		SignProposeAndPayAs(account).
 		RunPrintEventsFull()
 }
 
-func (otu *OverflowTestUtils) MintNFT(signer string, recipient string) {
+func (otu *OverflowTestUtils) MintNFT(signer, recipient string) {
 	otu.O.TransactionFromFile("mint_nft").
 		SignProposeAndPayAsService().
 		Args(otu.O.Arguments().
@@ -177,8 +183,11 @@ func (otu *OverflowTestUtils) MintNFT(signer string, recipient string) {
 		RunPrintEventsFull()
 }
 
-func (otu *OverflowTestUtils) SetupAccountForNFTs(account string) {
-	otu.O.TransactionFromFile("setup_account").
-		SignProposeAndPayAs(account).
+func (otu *OverflowTestUtils) TransferNFT(signer, recipient string, id uint64) {
+	otu.O.TransactionFromFile("transfer_nft").
+		SignProposeAndPayAs(signer).
+		Args(otu.O.Arguments().
+			Account(recipient).
+			UInt64(id)).
 		RunPrintEventsFull()
 }

--- a/backend/main/test_utils/strategy_utils.go
+++ b/backend/main/test_utils/strategy_utils.go
@@ -98,6 +98,33 @@ func (otu *OverflowTestUtils) GenerateListOfVotes(proposalId int, count int) *[]
 	return &votes
 }
 
+func (otu *OverflowTestUtils) GenerateCheatVote(proposalId int, count int) *[]VoteWithBalance {
+	votes := make([]VoteWithBalance, count)
+	choices := []string{"a", "b"}
+	for i := 0; i < count; i++ {
+		addr := "0x" + strconv.Itoa(i)
+		randomNumber := rand.Intn(2)
+		choice := choices[randomNumber]
+		v := models.Vote{
+			Proposal_id: proposalId, Addr: addr, Choice: choice,
+		}
+
+		// Balance is 1 FLOW * index
+		balance := 100000000 * (i + 1)
+
+		vote := VoteWithBalance{
+			Vote:                    v,
+			Primary_account_balance: uint64(balance),
+			Staking_balance:         uint64(balance * 5), // Make this different so staked/reg strats dont have same results
+			Block_height:            uint64(0),
+		}
+
+		votes[i] = vote
+	}
+
+	return &votes
+}
+
 func (otu *OverflowTestUtils) GenerateListOfVotesWithNFTs(
 	proposalId int,
 	count int,


### PR DESCRIPTION
'When a vote with an NFT balance is cast, the backend first checks DoesNFTExist, if the NFT already exists in the DB, the weight is not counted.'

• Implements `Attempt to cheat the NFT Strategy` integration test. This test asserts the cheat vote has no effect on the cheating user's vote weight. 

