### PR TITLE
cas-209 - Update version message on landing page

### DIFF
--- a/frontend/packages/client/src/components/Message.js
+++ b/frontend/packages/client/src/components/Message.js
@@ -14,14 +14,12 @@ const Message = ({ messageText = '', labelText = null, icon = null } = {}) => {
   return (
     <div className="container message-container">
       <div className="has-background-white-ter rounded-sm">
-        <div className="columns m-0 p-0">
+        <div className="columns is-mobile m-0 p-0">
           {labelText && (
             <WrapperResponsive
               classNames="column is-flex is-flex-grow-0 is-align-items-center pr-2"
               extraClasses="pl-3 py-3"
               extraStylesMobile={{
-                paddingTop: '20px',
-                paddingBottom: '10px',
                 fontSize: '12px',
               }}
             >
@@ -33,8 +31,6 @@ const Message = ({ messageText = '', labelText = null, icon = null } = {}) => {
             classNames="column is-flex is-flex-grow-1 is-align-items-center pl-2"
             extraClasses="pr-3 py-3"
             extraStylesMobile={{
-              paddingTop: '10px',
-              paddingBottom: '20px',
               fontSize: '12px',
             }}
             extraStyles={{

--- a/frontend/packages/client/src/pages/Home.js
+++ b/frontend/packages/client/src/pages/Home.js
@@ -6,7 +6,7 @@ import CommunitiesPresenter from 'components/Community/CommunitiesPresenter';
 import useUserCommunities from 'hooks/useUserCommunities';
 import useFeaturedCommunities from 'hooks/useFeaturedCommunities';
 
-const LinkToTemplate = () => (
+const LinkToIssueTemplate = () => (
   <a
     target="_blank"
     rel="noreferrer noopener"
@@ -56,7 +56,7 @@ export default function HomePage() {
         messageText={
           <p>
             This is an open beta of CAST.
-            <LinkToTemplate />
+            <LinkToIssueTemplate />
           </p>
         }
         labelText="Beta"

--- a/frontend/packages/client/src/pages/Home.js
+++ b/frontend/packages/client/src/pages/Home.js
@@ -6,6 +6,17 @@ import CommunitiesPresenter from 'components/Community/CommunitiesPresenter';
 import useUserCommunities from 'hooks/useUserCommunities';
 import useFeaturedCommunities from 'hooks/useFeaturedCommunities';
 
+const LinkToTemplate = () => (
+  <a
+    target="_blank"
+    rel="noreferrer noopener"
+    href="https://github.com/DapperCollectives/CAST/issues/new?assignees=markedconfidential&labels=bug&template=bug-report.md&title=%5BBUG%5D"
+    className="pl-1 py-4"
+  >
+    <span className="mr-2">Please report bugs here.</span>
+  </a>
+);
+
 export default function HomePage() {
   const {
     user: { addr },
@@ -42,8 +53,13 @@ export default function HomePage() {
   return (
     <section className="section">
       <Message
-        messageText="We are currently in alpha testing with the Flow developer community."
-        labelText="Alpha"
+        messageText={
+          <p>
+            This is an open beta of CAST.
+            <LinkToTemplate />
+          </p>
+        }
+        labelText="Beta"
       />
       {(loading || loadingFeaturedCommunities) && (
         <div style={{ height: '50vh' }}>


### PR DESCRIPTION

Desktop:

 <img width="787" alt="Screen Shot 2022-07-12 at 09 43 05" src="https://user-images.githubusercontent.com/7526740/178493504-b5d3eff0-6604-4559-860c-be11be41f0cc.png">
Mobile: 

<img width="363" alt="Screen Shot 2022-07-12 at 09 42 45" src="https://user-images.githubusercontent.com/7526740/178493517-380337db-378a-4a77-99bb-1fc7198ed96f.png">

