### PR TITLE
CAS-177: Integrate Leaderboard API with front-end

### DIFF
--- a/backend/main/leaderboard_test.go
+++ b/backend/main/leaderboard_test.go
@@ -163,36 +163,47 @@ func TestGetLeaderboardPaging(t *testing.T) {
 
 	communityId := otu.AddCommunities(1)[0]
 
-	numUsers := 6
-	numProposals := 1
-
-	otu.GenerateVotes(communityId, numProposals, numUsers)
+	otu.AddActiveProposals(communityId, 1)
 
 	count := 3
 
-	// First Page
+	// Leaderboard with no users because no votes yet
 	response1 := otu.GetCommunityLeaderboardAPIWithPaging(communityId, 0, count)
 	checkResponseCode(t, http.StatusOK, response1.Code)
 
 	var p1 test_utils.PaginatedResponseWithLeaderboardUser
 	json.Unmarshal(response1.Body.Bytes(), &p1)
 
-	// Second Page
-	response2 := otu.GetCommunityLeaderboardAPIWithPaging(communityId, 1, count)
+	numUsers := 6
+	numProposals := 1
+
+	otu.GenerateVotes(communityId, numProposals, numUsers)
+
+	// First Page
+	response2 := otu.GetCommunityLeaderboardAPIWithPaging(communityId, 0, count)
 	checkResponseCode(t, http.StatusOK, response2.Code)
 
 	var p2 test_utils.PaginatedResponseWithLeaderboardUser
 	json.Unmarshal(response2.Body.Bytes(), &p2)
 
-	// Invalid Page
-	response3 := otu.GetCommunityLeaderboardAPIWithPaging(communityId, 3, count)
+	// Second Page
+	response3 := otu.GetCommunityLeaderboardAPIWithPaging(communityId, 1, count)
 	checkResponseCode(t, http.StatusOK, response3.Code)
 
 	var p3 test_utils.PaginatedResponseWithLeaderboardUser
-	json.Unmarshal(response2.Body.Bytes(), &p3)
+	json.Unmarshal(response3.Body.Bytes(), &p3)
 
+	// Invalid Page
+	response4 := otu.GetCommunityLeaderboardAPIWithPaging(communityId, 3, count)
+	checkResponseCode(t, http.StatusOK, response4.Code)
+
+	var p4 test_utils.PaginatedResponseWithLeaderboardUser
+	json.Unmarshal(response4.Body.Bytes(), &p4)
+
+	expectedNoUsersLength := 0
 	expectedLength := 3
-	assert.Equal(t, expectedLength, len(p1.Data))
+	assert.Equal(t, expectedNoUsersLength, len(p1.Data))
 	assert.Equal(t, expectedLength, len(p2.Data))
 	assert.Equal(t, expectedLength, len(p3.Data))
+	assert.Equal(t, expectedLength, len(p4.Data))
 }

--- a/backend/main/models/community_users.go
+++ b/backend/main/models/community_users.go
@@ -113,10 +113,16 @@ func GetCommunityLeaderboard(db *s.Database, communityId, start, count int) ([]L
 	var defaultEarlyVoteWeight = 1
 	var defaultStreakWeight = 1
 
+	fmt.Println(start, count)
+
 	userAchievements, err := getUserAchievements(db, communityId)
 
 	if err != nil {
 		return leaderboardUsers, 0, err
+	}
+
+	if len(userAchievements) == 0 {
+		return leaderboardUsers, 0, nil
 	}
 
 	for _, user := range userAchievements {
@@ -140,7 +146,11 @@ func GetCommunityLeaderboard(db *s.Database, communityId, start, count int) ([]L
 
 		// If index invalid, set to last page
 		if startIndex >= len(leaderboardUsers) {
-			startIndex = len(leaderboardUsers) - count
+			if len(leaderboardUsers)-count >= 0 {
+				startIndex = len(leaderboardUsers) - count
+			} else {
+				startIndex = 0
+			}
 		}
 
 		if endIndex <= len(leaderboardUsers) {

--- a/backend/main/models/community_users.go
+++ b/backend/main/models/community_users.go
@@ -115,8 +115,6 @@ func GetCommunityLeaderboard(db *s.Database, communityId, start, count int) ([]L
 	var defaultStreakWeight = 1
 	var defaultWinningVoteWeight = 1
 
-	fmt.Println(start, count)
-
 	userAchievements, err := getUserAchievements(db, communityId)
 
 	if err != nil {

--- a/backend/main/test_utils/community_utils.go
+++ b/backend/main/test_utils/community_utils.go
@@ -221,6 +221,12 @@ func (otu *OverflowTestUtils) GetCommunityLeaderboardAPI(id int) *httptest.Respo
 	return response
 }
 
+func (otu *OverflowTestUtils) GetCommunityLeaderboardAPIWithPaging(id, start, count int) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest("GET", "/communities/"+strconv.Itoa(id)+"/leaderboard?start="+strconv.Itoa(start)+"&count="+strconv.Itoa(count), nil)
+	response := otu.ExecuteRequest(req)
+	return response
+}
+
 func (otu *OverflowTestUtils) GetCommunityUsersAPI(id int) *httptest.ResponseRecorder {
 	req, _ := http.NewRequest("GET", "/communities/"+strconv.Itoa(id)+"/users", nil)
 	response := otu.ExecuteRequest(req)

--- a/frontend/packages/client/src/api/constants.js
+++ b/frontend/packages/client/src/api/constants.js
@@ -1,3 +1,3 @@
 export const API_BASE_URL = process.env.REACT_APP_BACK_END_SERVER_API;
 
-export const COMMUNITIES_URL = `${API_BASE_URL}/communities/`;
+export const COMMUNITIES_URL = `${API_BASE_URL}/communities`;

--- a/frontend/packages/client/src/api/constants.js
+++ b/frontend/packages/client/src/api/constants.js
@@ -1,0 +1,3 @@
+export const API_BASE_URL = process.env.REACT_APP_BACK_END_SERVER_API;
+
+export const COMMUNITIES_URL = `${API_BASE_URL}/communities/`;

--- a/frontend/packages/client/src/api/leaderboard.js
+++ b/frontend/packages/client/src/api/leaderboard.js
@@ -1,0 +1,17 @@
+import { checkResponse } from '../utils';
+import { COMMUNITIES_URL } from './constants';
+
+const LEADERBOARD_SIZE = 10;
+const getLeaderBoardUrl = (communityId) =>
+  `${COMMUNITIES_URL}/${communityId}/leaderboard?count=${LEADERBOARD_SIZE}`;
+
+const fetchLeaderBoard = async (communityId) => {
+  try {
+    const response = await fetch(getLeaderBoardUrl(communityId));
+    return await checkResponse(response);
+  } catch (err) {
+    throw err;
+  }
+};
+
+export default fetchLeaderBoard;

--- a/frontend/packages/client/src/api/leaderboard.js
+++ b/frontend/packages/client/src/api/leaderboard.js
@@ -1,13 +1,13 @@
 import { checkResponse } from '../utils';
 import { COMMUNITIES_URL } from './constants';
 
-const LEADERBOARD_SIZE = 10;
-const getLeaderBoardUrl = (communityId) =>
-  `${COMMUNITIES_URL}/${communityId}/leaderboard?count=${LEADERBOARD_SIZE}`;
+const DEFAULT_PAGE_SIZE = 10;
+const getLeaderBoardUrl = (communityId, pageSize) =>
+  `${COMMUNITIES_URL}/${communityId}/leaderboard?count=${pageSize}`;
 
-const fetchLeaderBoard = async (communityId) => {
+const fetchLeaderBoard = async (communityId, pageSize = DEFAULT_PAGE_SIZE) => {
   try {
-    const response = await fetch(getLeaderBoardUrl(communityId));
+    const response = await fetch(getLeaderBoardUrl(communityId, pageSize));
     return await checkResponse(response);
   } catch (err) {
     throw err;

--- a/frontend/packages/client/src/components/LeaderBoard.js
+++ b/frontend/packages/client/src/components/LeaderBoard.js
@@ -21,8 +21,11 @@ const Row = ({ index, addr, score, classNameIndex }) => {
   );
 };
 
-export default function LeaderBoard({ onClickViewMore = () => {} } = {}) {
-  const { data, loading } = useLeaderBoard();
+export default function LeaderBoard({
+  onClickViewMore = () => {},
+  communityId,
+} = {}) {
+  const { data, isLoading } = useLeaderBoard({ communityId });
   const style = {};
 
   return (
@@ -36,7 +39,7 @@ export default function LeaderBoard({ onClickViewMore = () => {} } = {}) {
       </WrapperResponsive>
       <table className="table is-fullwidth">
         <tbody className="is-scrollable-table" style={style}>
-          {!loading &&
+          {!isLoading &&
             data?.leaderBoard.map((datum, index) => {
               const userIndex = index + 1;
               const styleIndex =
@@ -74,7 +77,7 @@ export default function LeaderBoard({ onClickViewMore = () => {} } = {}) {
             })}
         </tbody>
       </table>
-      {!loading && data?.currentUser && (
+      {!isLoading && data?.currentUser && (
         <table className="table is-fullwidth">
           <tbody className="is-scrollable-table" style={style}>
             <Row

--- a/frontend/packages/client/src/components/LeaderBoard.js
+++ b/frontend/packages/client/src/components/LeaderBoard.js
@@ -14,9 +14,7 @@ const Row = ({ index, addr, score, classNameIndex }) => {
     <tr className="table-row">
       <td className={clnIndex}>{index}</td>
       <td>{addr}</td>
-      <td style={smallRowStyle} className="smaller-text">
-        {score}
-      </td>
+      <td style={smallRowStyle}>{score}</td>
     </tr>
   );
 };
@@ -70,7 +68,9 @@ export default function LeaderBoard({
                     </div>
                   }
                   score={
-                    <div className="has-text-weight-bold">{datum?.score}</div>
+                    <div className="is-flex flex-1 is-justify-content-center has-text-weight-bold smaller-text">
+                      {datum?.score}
+                    </div>
                   }
                 />
               );
@@ -99,7 +99,7 @@ export default function LeaderBoard({
                 </div>
               }
               score={
-                <div className="has-text-weight-bold">
+                <div className="is-flex flex-1 is-justify-content-center has-text-weight-bold smaller-text">
                   {data?.currentUser.score}
                 </div>
               }

--- a/frontend/packages/client/src/hooks/useLeaderBoard.js
+++ b/frontend/packages/client/src/hooks/useLeaderBoard.js
@@ -1,70 +1,29 @@
-import { useReducer, useEffect, useCallback } from 'react';
-import { defaultReducer, INITIAL_STATE } from '../reducers';
-// import { checkResponse } from "../utils";
+import { useQuery } from 'react-query';
 import { useErrorHandlerContext } from '../contexts/ErrorHandler';
+import fetchLeaderBoard from 'api/leaderboard';
 
-export default function useLeaderBoard() {
-  const [state, dispatch] = useReducer(defaultReducer, INITIAL_STATE);
+export default function useLeaderBoard({ communityId = 0 } = {}) {
   const { notifyError } = useErrorHandlerContext();
+  const { isLoading, isError, data, error } = useQuery(
+    ['leaderboard'],
+    async () => fetchLeaderBoard(communityId)
+  );
 
-  const getLeaderBoard = useCallback(async () => {
-    dispatch({ type: 'PROCESSING' });
-    // const url = `${process.env.REACT_APP_BACK_END_SERVER_API}/..`;
-    try {
-      // uncomment this lines when endpoint is ready
-      // const response = await fetch(url);
-      // const allowList = await checkResponse(response);
-
-      // fake data
-      const result = {
-        leaderBoard: [
-          {
-            addr: 'nick.fn',
-            score: '123 $XYZ',
-          },
-          {
-            addr: 'askash.find',
-            score: '123 $XYZ',
-          },
-          {
-            addr: 'm33stie.fn',
-            score: '123 $XYZ',
-          },
-          {
-            addr: '0xd1...0b9b',
-            score: '123 $XYZ',
-          },
-          {
-            addr: '0ak.fn',
-            score: '123 $XYZ',
-          },
-        ],
-        currentUser: {
-          addr: 'joshprin...',
-          score: '123 $XYZ',
-          index: 122,
-        },
-      };
-
-      dispatch({ type: 'SUCCESS', payload: result });
-    } catch (err) {
-      // notify user of error
-      notifyError(
-        err,
-        // uncomment this line when endpoint is ready
-        //url
-        'urlToEndpoint'
-      );
-      dispatch({ type: 'ERROR', payload: { errorData: err.message } });
-    }
-  }, [dispatch, notifyError]);
-
-  useEffect(() => {
-    getLeaderBoard();
-  }, [getLeaderBoard]);
+  if (isError) {
+    notifyError(error);
+  }
 
   return {
-    ...state,
-    getLeaderBoard,
+    isLoading,
+    isError,
+    error,
+    data: {
+      leaderBoard: data?.data ?? [],
+      currentUser: {
+        addr: 'joshprin...',
+        score: '123 $XYZ',
+        index: 122,
+      },
+    },
   };
 }

--- a/frontend/packages/client/src/pages/Community.js
+++ b/frontend/packages/client/src/pages/Community.js
@@ -185,7 +185,7 @@ export default function Community() {
 
   // these two fields should be coming from backend as configuration
   const showPulse = false;
-  const showLeaderBoard = false;
+  const showLeaderBoard = true;
 
   // check for allowing only three options
   if (!['proposals', 'about', 'members'].includes(activeTab)) {
@@ -377,7 +377,10 @@ export default function Community() {
                     communityPulse={showPulse && <CommunityPulse />}
                     leaderBoard={
                       showLeaderBoard && (
-                        <LeaderBoard onClickViewMore={onClickViewMore} />
+                        <LeaderBoard
+                          onClickViewMore={onClickViewMore}
+                          communityId={community.id}
+                        />
                       )
                     }
                     communityLinks={


### PR DESCRIPTION
**Ticket:** [CAS-177](https://linear.app/dappercollectives/issue/CAS-177/add-leaderboard-score-to-community-member-page)

**Description**

Connects Leaderboard API with the Leaderboard component on the community page

<img width="996" alt="Screen Shot 2022-07-12 at 11 16 41 AM" src="https://user-images.githubusercontent.com/22734700/178542490-66abc679-de73-4356-8c3e-53f1de2d0a52.png">

NOTE: Added a pattern to separate the API logic from the useQuery hook. This promotes reusability of the api logic, and simplifies the fetching hooks so that the only logic relates to the hook, and not to the fetching.