### PR TITLE
rearrange community page tab order and set default tab to proposals

### DIFF
--- a/frontend/packages/client/src/components/Community/CommunityCard.js
+++ b/frontend/packages/client/src/components/Community/CommunityCard.js
@@ -51,7 +51,7 @@ const CommunityCard = ({ logo, name, description, id, slug }) => {
 
   return (
     <>
-      <Link to={`/community/${id}?tab=about`} style={{ color: 'inherit' }}>
+      <Link to={`/community/${id}?tab=proposals`} style={{ color: 'inherit' }}>
         <div className="is-flex is-flex-grow-1 rounded-sm border-light p-5 is-flex-direction-column transition-all community-card">
           <div className="columns is-multiline is-flex-grow-1 is-mobile">
             <div className="column is-narrow">

--- a/frontend/packages/client/src/pages/Community.js
+++ b/frontend/packages/client/src/pages/Community.js
@@ -189,7 +189,7 @@ export default function Community() {
 
   // check for allowing only three options
   if (!['proposals', 'about', 'members'].includes(activeTab)) {
-    history.push(`/community/${communityId}?tab=about`);
+    history.push(`/community/${communityId}?tab=proposals`);
   }
   // navigation from leader board to member list
   const onClickViewMore = () => {
@@ -329,22 +329,13 @@ export default function Community() {
       ) : null}
       <div className="section pt-0">
         <div className="container full-height community-content">
-          {loading && <Loader fullHeight />}
-          {!loading && (
+          {loading ? (
+            <Loader fullHeight />
+          ) : (
             <div className="columns m-0 p-0">
               <div className="column p-0">
                 <div className="tabs tabs-community is-medium small-text">
                   <ul className="tabs-community-list">
-                    <li
-                      className={`${activeTabMap['about'] ? 'is-active' : ''}`}
-                    >
-                      <Tablink
-                        linkText="About"
-                        linkUrl={`/community/${community.id}?tab=about`}
-                        isActive={activeTabMap['about']}
-                        className="tab-community pb-4 pl-2 pr-0 mr-4"
-                      />
-                    </li>
                     <li
                       className={`${
                         activeTabMap['proposals'] ? 'is-active' : ''
@@ -354,7 +345,7 @@ export default function Community() {
                         linkText="Proposals"
                         linkUrl={`/community/${community.id}?tab=proposals`}
                         isActive={activeTabMap['proposals']}
-                        className="tab-community pb-4 pr-1 pl-0 mx-4"
+                        className="tab-community pb-4 px-2 mr-4"
                       />
                     </li>
                     <li
@@ -366,7 +357,17 @@ export default function Community() {
                         linkText="Members"
                         linkUrl={`/community/${community.id}?tab=members`}
                         isActive={activeTabMap['members']}
-                        className="tab-community pb-4 pr-1 pl-0 ml-4"
+                        className="tab-community pb-4 px-2 mx-4"
+                      />
+                    </li>
+                    <li
+                      className={`${activeTabMap['about'] ? 'is-active' : ''}`}
+                    >
+                      <Tablink
+                        linkText="About"
+                        linkUrl={`/community/${community.id}?tab=about`}
+                        isActive={activeTabMap['about']}
+                        className="tab-community pb-4 px-2 ml-4"
                       />
                     </li>
                   </ul>


### PR DESCRIPTION
Change the order of the community page navigation to:

- Proposals
- Members
- About

Also changes the default tab to be "proposals" when none is provided, as well as making CommunityCard default to `proposals`