### PR TITLE
CAS-122: Fix community banner image to support non-square images

### DIFF
--- a/frontend/packages/client/src/pages/Community.js
+++ b/frontend/packages/client/src/pages/Community.js
@@ -263,7 +263,7 @@ export default function Community() {
         !notMobile,
     }
   );
-  const imageClases = classnames(
+  const imageClasses = classnames(
     {
       'rounded-full community-logo-mobile': !notMobile,
     },
@@ -279,13 +279,19 @@ export default function Community() {
             <div className="is-flex community-specific">
               <div className={imageContainerClasses}>
                 {logo ? (
-                  <img
-                    className={imageClases}
-                    alt="community banner"
-                    src={logo}
-                    height="85px"
-                    width="85px"
-                  />
+                  <div
+                    role="img"
+                    aria-label="community banner"
+                    className={imageClasses}
+                    style={{
+                      width: 85,
+                      height: 85,
+                      backgroundImage: `url(${logo})`,
+                      backgroundRepeat: 'no-repeat',
+                      backgroundPosition: 'center',
+                      backgroundSize: 'cover',
+                    }}
+                  ></div>
                 ) : (
                   <Blockies
                     seed={slug ?? `seed-${id}`}


### PR DESCRIPTION
**Ticket:** [CAS-122](https://linear.app/dappercollectives/issue/CAS-122/non-square-images-for-community-avatar)

**Description:**

Changes the logo handling to be a background image on a div, so image dimensions don't matter. Image positioning will be centered on div.

<img width="621" alt="Screen Shot 2022-07-12 at 3 32 37 PM" src="https://user-images.githubusercontent.com/22734700/178589979-7da11575-cf0d-4b69-8189-555f6e524f1f.png">

