### PR TITLE
fix overflowing community titles and cap title input to 50 characters

### DIFF
--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -532,9 +532,14 @@ span[data-tooltip]
 
 .word-break-all
 	word-break: break-all
-
 .word-break
 	word-break: break-word
+.line-clamp-2
+	display: -webkit-box
+	-webkit-line-clamp: 2
+	-webkit-box-orient: vertical
+	overflow: hidden
+
 .mx-loader
 	margin-left: 0.1rem !important
 	margin-right: 0.1rem !important

--- a/frontend/packages/client/src/components/Community/CommunityCard.js
+++ b/frontend/packages/client/src/components/Community/CommunityCard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import JoinCommunityButton from './JoinCommunityButton';
+import WrapperResponsive from 'components/WrapperResponsive';
 import Blockies from 'react-blockies';
 import { useMediaQuery } from 'hooks';
 /**
@@ -13,19 +14,6 @@ const CommunityCard = ({ logo, name, body, id, slug }) => {
     maxHeight: '3rem',
     overflow: 'hidden',
   };
-
-  const isNotMobile = useMediaQuery();
-  const avatarSize = isNotMobile
-    ? {
-        logo: { width: 96, height: 96 },
-        blockie: { size: 10, scale: 9.6 },
-        columnStyle: { maxHeight: '120px' },
-      }
-    : {
-        logo: { width: 48, height: 48 },
-        blockie: { size: 10, scale: 4.8 },
-        columnStyle: { maxHeight: '72px' },
-      };
 
   return (
     <>
@@ -71,7 +59,7 @@ const CommunityCard = ({ logo, name, body, id, slug }) => {
                 {body}
               </p>
             </div>
-            <div className="column is-12-mobile p-0-mobile is-narrow-tablet is-flex is-flex-direction-column is-justify-content-start">
+            <div className="column is-narrow is-flex is-flex-direction-column is-justify-content-start">
               <JoinCommunityButton communityId={id} darkMode={false} />
             </div>
           </div>

--- a/frontend/packages/client/src/components/Community/CommunityCard.js
+++ b/frontend/packages/client/src/components/Community/CommunityCard.js
@@ -64,7 +64,7 @@ const CommunityCard = ({ logo, name, body, id, slug }) => {
                   : {}
               }
             >
-              <div className="is-size-5 is-size-6-mobile mb-2 is-4 is-6-mobile pt-0-mobile">
+              <div className="is-size-5 is-size-6-mobile mb-2 is-4 is-6-mobile pt-0-mobile line-clamp-2">
                 {name}
               </div>
               <p className="has-text-grey small-text" style={descriptionStyle}>

--- a/frontend/packages/client/src/components/Community/CommunityCard.js
+++ b/frontend/packages/client/src/components/Community/CommunityCard.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import JoinCommunityButton from './JoinCommunityButton';
-import WrapperResponsive from 'components/WrapperResponsive';
 import Blockies from 'react-blockies';
 import { useMediaQuery } from 'hooks';
 /**
@@ -14,6 +13,19 @@ const CommunityCard = ({ logo, name, body, id, slug }) => {
     maxHeight: '3rem',
     overflow: 'hidden',
   };
+
+  const isNotMobile = useMediaQuery();
+  const avatarSize = isNotMobile
+    ? {
+        logo: { width: 96, height: 96 },
+        blockie: { size: 10, scale: 9.6 },
+        columnStyle: { maxHeight: '120px' },
+      }
+    : {
+        logo: { width: 48, height: 48 },
+        blockie: { size: 10, scale: 4.8 },
+        columnStyle: { maxHeight: '72px' },
+      };
 
   return (
     <>
@@ -59,7 +71,7 @@ const CommunityCard = ({ logo, name, body, id, slug }) => {
                 {body}
               </p>
             </div>
-            <div className="column is-narrow is-flex is-flex-direction-column is-justify-content-start">
+            <div className="column is-12-mobile p-0-mobile is-narrow-tablet is-flex is-flex-direction-column is-justify-content-start">
               <JoinCommunityButton communityId={id} darkMode={false} />
             </div>
           </div>

--- a/frontend/packages/client/src/components/Community/CommunityEditorProfile.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorProfile.js
@@ -198,6 +198,7 @@ function CommunityEditorProfile({
         value={communityName}
         onChange={(event) => setCommunityName(event.target.value)}
         disabled={isUpdating}
+        maxLength={50}
       />
       <textarea
         className="text-area rounded-sm border-light p-3 column is-full mt-5"

--- a/frontend/packages/client/src/components/CommunityCreate/StepOne.js
+++ b/frontend/packages/client/src/components/CommunityCreate/StepOne.js
@@ -224,6 +224,7 @@ export default function StepOne({
           name="community_name"
           className="rounded-sm border-light p-3 column is-full mt-2"
           value={communityName || ''}
+          maxLength={50}
           onChange={(event) => setData({ communityName: event.target.value })}
         />
         <textarea


### PR DESCRIPTION
- adds a `line-clamp` rule to the community titles so they dont go over 2 lines of text
- adds 50 character `maxLength` to title input

![newname](https://user-images.githubusercontent.com/15314629/179027302-60e7ede8-ad9f-4e1e-bac6-52c9dfb1bce5.png)
![newnamemobile](https://user-images.githubusercontent.com/15314629/179027319-1f9d9796-3bc7-432f-b51c-74630734e231.png)

Relies on https://github.com/DapperCollectives/CAST/pull/145