### PR TITLE
CAS-227 - Update text link

### DIFF
--- a/frontend/packages/client/src/pages/Home.js
+++ b/frontend/packages/client/src/pages/Home.js
@@ -10,10 +10,10 @@ const LinkToIssueTemplate = () => (
   <a
     target="_blank"
     rel="noreferrer noopener"
-    href="https://github.com/DapperCollectives/CAST/issues/new?assignees=markedconfidential&labels=bug&template=bug-report.md&title=%5BBUG%5D"
+    href="https://docs.cast.fyi"
     className="pl-1 py-4"
   >
-    <span className="mr-2">Please report bugs here.</span>
+    <span className="mr-2">Learn more about decision-making on Flow here.</span>
   </a>
 );
 


### PR DESCRIPTION
Updates on link and text:


<img width="763" alt="Screen Shot 2022-07-14 at 16 05 33" src="https://user-images.githubusercontent.com/7526740/179063250-a2fa9cc9-65e7-49ec-8910-df680e5b9bd3.png">

