### PR TITLE
make create community steps the same color scheme as create proposal

### DIFF
--- a/frontend/packages/client/src/components/StepByStep/index.js
+++ b/frontend/packages/client/src/components/StepByStep/index.js
@@ -1,21 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { ArrowLeft, CheckMark } from '../Svg';
 import Loader from '../Loader';
-import defaultsDeep from 'lodash/defaultsDeep';
-
-const defaultStyles = {
-  currentStep: {
-    icon: {
-      textColor: 'has-text-black',
-      hexBackgroundColor: 'has-background-orange',
-    },
-  },
-  completeStep: {
-    icon: {
-      hexBackgroundColor: '#44C42F',
-    },
-  },
-};
 
 function StepByStep({
   finalLabel,
@@ -26,10 +11,7 @@ function StepByStep({
   submittingMessage,
   passNextToComp = false,
   passSubmitToComp = false,
-  styleConfig = {},
 } = {}) {
-  const customStyle = defaultsDeep(styleConfig, defaultStyles);
-
   const [currentStep, setCurrentStep] = useState(0);
   const [showPreStep, setShowPreStep] = useState(!!preStep);
   const [isStepValid, setStepValid] = useState(false);
@@ -94,15 +76,11 @@ function StepByStep({
       stepClasses.push('mb-6 is-align-items-center');
     }
 
-    const currentStepIconStyle = Object.values(
-      customStyle.currentStep.icon
-    ).join(' ');
-
     if (!showPreStep && stepIdx === currentStep) {
       return (
         <div className={`is-flex ${stepClasses.join(' ')}`} key={stepIdx}>
           <div
-            className={`rounded-full ${currentStepIconStyle} is-flex is-align-items-center is-justify-content-center`}
+            className={`rounded-full has-text-black has-background-orange is-flex is-align-items-center is-justify-content-center`}
             style={{
               width: 30,
               height: 30,
@@ -116,9 +94,7 @@ function StepByStep({
     } else if (!showPreStep && currentStep > stepIdx) {
       return (
         <div className={`is-flex ${stepClasses.join(' ')}`} key={stepIdx}>
-          <CheckMark
-            circleFill={customStyle.completeStep.icon.hexBackgroundColor}
-          />
+          <CheckMark circleFill="#44C42F" />
           {stepLabel ? <span className="ml-4">{stepLabel}</span> : divider}
         </div>
       );

--- a/frontend/packages/client/src/components/StepByStep/index.js
+++ b/frontend/packages/client/src/components/StepByStep/index.js
@@ -80,7 +80,8 @@ function StepByStep({
       return (
         <div className={`is-flex ${stepClasses.join(' ')}`} key={stepIdx}>
           <div
-            className={`rounded-full has-text-black has-background-orange is-flex is-align-items-center is-justify-content-center`}
+            className="rounded-full has-text-black has-background-orange is-flex 
+              is-align-items-center is-justify-content-center"
             style={{
               width: 30,
               height: 30,

--- a/frontend/packages/client/src/pages/CommunityCreate.js
+++ b/frontend/packages/client/src/pages/CommunityCreate.js
@@ -137,14 +137,6 @@ export default function CommunityCreate() {
     finalLabel: 'Publish',
     onSubmit,
     isSubmitting: creatingCommunity && !error,
-    styleConfig: {
-      currentStep: {
-        icon: {
-          textColor: 'has-text-white',
-          backgroundColor: 'has-background-black',
-        },
-      },
-    },
     submittingMessage: 'Creating community...',
     passNextToComp: true,
     passSubmitToComp: true,


### PR DESCRIPTION
the colors for the steps while creating a community should be the same as when creating a proposal. this PR removes the customization option of the step colors in StepByStep to make them consistent across all uses