### PR TITLE
Main -> Staging

### DIFF
--- a/backend/main/server/app.go
+++ b/backend/main/server/app.go
@@ -1657,6 +1657,7 @@ func (a *App) handleGetCommunityLeaderboard(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	addr := r.FormValue("addr")
 	count, _ := strconv.Atoi(r.FormValue("count"))
 	start, _ := strconv.Atoi(r.FormValue("start"))
 	if count > 100 || count < 1 {
@@ -1666,15 +1667,15 @@ func (a *App) handleGetCommunityLeaderboard(w http.ResponseWriter, r *http.Reque
 		start = 0
 	}
 
-	users, totalRecords, err := models.GetCommunityLeaderboard(a.DB, communityId, start, count)
+	leaderboard, totalRecords, err := models.GetCommunityLeaderboard(a.DB, communityId, addr, start, count)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	response := shared.GetPaginatedResponseWithPayload(users, start, count, totalRecords)
+	response := shared.GetPaginatedResponseWithPayload(leaderboard.Users, start, count, totalRecords)
+	response.Data = leaderboard
 	respondWithJSON(w, http.StatusOK, response)
-
 }
 
 func (a *App) handleGetUserCommunities(w http.ResponseWriter, r *http.Request) {

--- a/backend/main/test_utils/community_utils.go
+++ b/backend/main/test_utils/community_utils.go
@@ -30,11 +30,11 @@ type PaginatedResponseWithUserType struct {
 }
 
 type PaginatedResponseWithLeaderboardUser struct {
-	Data         []models.LeaderboardUserPayload `json:"data"`
-	Start        int                             `json:"start"`
-	Count        int                             `json:"count"`
-	TotalRecords int                             `json:"totalRecords"`
-	Next         int                             `json:"next"`
+	Data         models.LeaderboardPayload `json:"data"`
+	Start        int                       `json:"start"`
+	Count        int                       `json:"count"`
+	TotalRecords int                       `json:"totalRecords"`
+	Next         int                       `json:"next"`
 }
 
 var (
@@ -217,6 +217,12 @@ func (otu *OverflowTestUtils) GetCommunityAPI(id int) *httptest.ResponseRecorder
 
 func (otu *OverflowTestUtils) GetCommunityLeaderboardAPI(id int) *httptest.ResponseRecorder {
 	req, _ := http.NewRequest("GET", "/communities/"+strconv.Itoa(id)+"/leaderboard", nil)
+	response := otu.ExecuteRequest(req)
+	return response
+}
+
+func (otu *OverflowTestUtils) GetCommunityLeaderboardAPIWithCurrentUser(id int, addr string) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest("GET", "/communities/"+strconv.Itoa(id)+"/leaderboard?addr="+addr, nil)
 	response := otu.ExecuteRequest(req)
 	return response
 }

--- a/backend/migrations/000025_rename_achievements_sequence.down.sql
+++ b/backend/migrations/000025_rename_achievements_sequence.down.sql
@@ -1,0 +1,1 @@
+ALTER SEQUENCE IF EXISTS user_achievements_id_seq RENAME TO community_users_achievements_id_seq

--- a/backend/migrations/000025_rename_achievements_sequence.up.sql
+++ b/backend/migrations/000025_rename_achievements_sequence.up.sql
@@ -1,0 +1,1 @@
+ALTER SEQUENCE IF EXISTS community_users_achievements_id_seq RENAME TO user_achievements_id_seq

--- a/frontend/packages/client/src/api/leaderboard.js
+++ b/frontend/packages/client/src/api/leaderboard.js
@@ -2,12 +2,18 @@ import { checkResponse } from '../utils';
 import { COMMUNITIES_URL } from './constants';
 
 const DEFAULT_PAGE_SIZE = 10;
-const getLeaderBoardUrl = (communityId, pageSize) =>
-  `${COMMUNITIES_URL}/${communityId}/leaderboard?count=${pageSize}`;
+const getLeaderBoardUrl = (communityId, addr, pageSize) =>
+  `${COMMUNITIES_URL}/${communityId}/leaderboard?count=${pageSize}&addr=${addr}`;
 
-const fetchLeaderBoard = async (communityId, pageSize = DEFAULT_PAGE_SIZE) => {
+const fetchLeaderBoard = async (
+  communityId,
+  addr,
+  pageSize = DEFAULT_PAGE_SIZE
+) => {
   try {
-    const response = await fetch(getLeaderBoardUrl(communityId, pageSize));
+    const response = await fetch(
+      getLeaderBoardUrl(communityId, addr, pageSize)
+    );
     return await checkResponse(response);
   } catch (err) {
     throw err;

--- a/frontend/packages/client/src/components/LeaderBoard.js
+++ b/frontend/packages/client/src/components/LeaderBoard.js
@@ -1,3 +1,4 @@
+import { Web3Consumer } from 'contexts/Web3';
 import React from 'react';
 import Blockies from 'react-blockies';
 import { WrapperResponsive } from '../components';
@@ -19,11 +20,13 @@ const Row = ({ index, addr, score, classNameIndex }) => {
   );
 };
 
-export default function LeaderBoard({
+const LeaderBoard = ({
   onClickViewMore = () => {},
   communityId,
-} = {}) {
-  const { data, isLoading } = useLeaderBoard({ communityId });
+  web3,
+} = {}) => {
+  const { user } = web3;
+  const { data, isLoading } = useLeaderBoard({ communityId, addr: user?.addr });
   const style = {};
 
   return (
@@ -38,7 +41,7 @@ export default function LeaderBoard({
       <table className="table is-fullwidth">
         <tbody className="is-scrollable-table" style={style}>
           {!isLoading &&
-            data?.leaderBoard.map((datum, index) => {
+            data?.users.map((datum, index) => {
               const userIndex = index + 1;
               const styleIndex =
                 index === 0
@@ -114,4 +117,6 @@ export default function LeaderBoard({
       </div>
     </div>
   );
-}
+};
+
+export default Web3Consumer(LeaderBoard);

--- a/frontend/packages/client/src/hooks/useLeaderBoard.js
+++ b/frontend/packages/client/src/hooks/useLeaderBoard.js
@@ -2,28 +2,27 @@ import { useQuery } from 'react-query';
 import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 import fetchLeaderBoard from 'api/leaderboard';
 
-export default function useLeaderBoard({ communityId = 0 } = {}) {
+export default function useLeaderBoard({ communityId = 0, addr = '' } = {}) {
   const { notifyError } = useErrorHandlerContext();
   const { isLoading, isError, data, error } = useQuery(
-    ['leaderboard'],
-    async () => fetchLeaderBoard(communityId)
+    ['leaderboard', addr],
+    async () => fetchLeaderBoard(communityId, addr)
   );
 
   if (isError) {
     notifyError(error);
   }
 
+  const users = data?.data?.users ?? [];
+  const currentUser = data?.data?.currentUser;
+
   return {
     isLoading,
     isError,
     error,
     data: {
-      leaderBoard: data?.data ?? [],
-      currentUser: {
-        addr: 'joshprin...',
-        score: '123 $XYZ',
-        index: 122,
-      },
+      users,
+      currentUser: currentUser?.addr ? currentUser : undefined,
     },
   };
 }


### PR DESCRIPTION
* CAS-177: Integrate Leaderboard API with front-end

* CAS-177: Fix bug in leaderboard paging

* CAS-177: Add pageSize to fetchLeaderboard

* CAS-177: Fix stlying for score

* CAS-229: Add Current User to leaderboard

* CAS-229: Fix broken proposal test

* CAS-229: Rename achievements sequence table

* CAS-229: Rename data.leaderboard to data.users

* CAS-229: Update leaderboard api json

* CAS-229: Resequence migration files

* CAS-229: Resequence migration files

Co-authored-by: Jonathan <jon.bluks@gmail.com>