### PR TITLE
animate active bar under community tab links

### DIFF
--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -300,7 +300,7 @@ hr
 	border-bottom-width: 3px
 	border-bottom-style: solid
 	&.tab-community
-		border-bottom-color: $light-green
+		border-bottom-color: transparent
 		color: $black
 		border-bottom-width: 2px
 		border-bottom-style: solid

--- a/frontend/packages/client/src/components/Tablink.js
+++ b/frontend/packages/client/src/components/Tablink.js
@@ -1,52 +1,59 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { Link } from 'react-router-dom';
 import { Star } from 'components/Svg';
 
-const Tablink = ({
-  linkText,
-  linkUrl,
-  isActive,
-  onlyLink,
-  onClick = () => {},
-  className = '',
-}) => {
-  const textClass = `${className} ${
-    isActive ? 'has-text-black' : 'has-text-grey'
-  }`;
+const Tablink = forwardRef(
+  (
+    {
+      linkText,
+      linkUrl,
+      isActive,
+      onlyLink,
+      onClick = () => {},
+      className = '',
+    },
+    ref
+  ) => {
+    const textClass = `${className} ${
+      isActive ? 'has-text-black' : 'has-text-grey'
+    }`;
 
-  if (!linkUrl) {
-    return (
-      // eslint-disable-next-line jsx-a11y/anchor-is-valid
-      <a className={textClass} onClick={onClick}>
-        {linkText}
-      </a>
+    if (!linkUrl) {
+      return (
+        // eslint-disable-next-line jsx-a11y/anchor-is-valid
+        <a className={textClass} onClick={onClick}>
+          {linkText}
+        </a>
+      );
+    }
+
+    if (onlyLink) {
+      return (
+        <Link to={linkUrl} className={textClass}>
+          {linkText}
+        </Link>
+      );
+    }
+
+    const link = isActive ? (
+      <>
+        <b className="pr-2">{linkText + ' '}</b>
+        <Star width="13" height="13" fill="black" />
+      </>
+    ) : (
+      <>{linkText}</>
     );
-  }
 
-  if (onlyLink) {
     return (
-      <Link to={linkUrl} className={textClass}>
-        {linkText}
+      <Link to={linkUrl} className={textClass} ref={ref}>
+        <div
+          className={`is-flex is-align-items-center is-justify-content-left`}
+        >
+          {link}
+        </div>
       </Link>
     );
   }
-
-  const link = isActive ? (
-    <>
-      <b className="pr-2">{linkText + ' '}</b>
-      <Star width="13" height="13" fill="black" />
-    </>
-  ) : (
-    <>{linkText}</>
-  );
-
-  return (
-    <Link to={linkUrl} className={textClass}>
-      <div className={`is-flex is-align-items-center is-justify-content-left`}>
-        {link}
-      </div>
-    </Link>
-  );
-};
+);
 
 export default Tablink;

--- a/frontend/packages/client/src/pages/Community.js
+++ b/frontend/packages/client/src/pages/Community.js
@@ -19,6 +19,7 @@ import {
   useCommunityUsers,
   useUserRoleOnCommunity,
   useCommunityMembers,
+  useWindowDimensions,
 } from '../hooks';
 import { useWebContext } from '../contexts/Web3';
 import Blockies from 'react-blockies';
@@ -137,6 +138,7 @@ export default function Community() {
 
   const history = useHistory();
 
+  const { width: windowWidth } = useWindowDimensions();
   const [activeWidth, setActiveWidth] = useState(105);
   const [activeLeft, setActiveLeft] = useState(0);
 
@@ -215,7 +217,7 @@ export default function Community() {
     const offsetLeft = elRect.left - parentRect.left;
     setActiveWidth(el.offsetWidth);
     setActiveLeft(offsetLeft);
-  }, [activeTab]);
+  }, [activeTab, windowWidth]);
 
   const notMobile = useMediaQuery();
 

--- a/frontend/packages/client/src/pages/Community.js
+++ b/frontend/packages/client/src/pages/Community.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useHistory, useParams, Link } from 'react-router-dom';
 import classnames from 'classnames';
 import {
@@ -137,6 +137,9 @@ export default function Community() {
 
   const history = useHistory();
 
+  const [activeWidth, setActiveWidth] = useState(105);
+  const [activeLeft, setActiveLeft] = useState(0);
+
   const { activeTab } = useQueryParams({ activeTab: 'tab' });
 
   const { data: community, loading, error } = useCommunityDetails(communityId);
@@ -192,6 +195,27 @@ export default function Community() {
     proposals: activeTab === 'proposals',
     members: activeTab === 'members',
   };
+
+  const wrapperRef = useRef();
+  const aboutRef = useRef();
+  const proposalRef = useRef();
+  const memberRef = useRef();
+
+  useEffect(() => {
+    const refMap = {
+      about: aboutRef,
+      proposals: proposalRef,
+      members: memberRef,
+    };
+    const el = refMap[activeTab].current;
+    if (!el) return;
+
+    const elRect = el.getBoundingClientRect();
+    const parentRect = wrapperRef.current.getBoundingClientRect();
+    const offsetLeft = elRect.left - parentRect.left;
+    setActiveWidth(el.offsetWidth);
+    setActiveLeft(offsetLeft);
+  }, [activeTab]);
 
   const notMobile = useMediaQuery();
 
@@ -262,6 +286,7 @@ export default function Community() {
       'rounded-full': notMobile,
     }
   );
+
   return (
     <section className="full-height pt-0">
       {community ? (
@@ -333,13 +358,29 @@ export default function Community() {
             <div className="columns m-0 p-0">
               <div className="column p-0">
                 <div className="tabs tabs-community is-medium small-text">
-                  <ul className="tabs-community-list">
+                  <ul
+                    ref={wrapperRef}
+                    className="tabs-community-list"
+                    style={{ position: 'relative' }}
+                  >
+                    <div
+                      style={{
+                        transition: '0.1s all',
+                        position: 'absolute',
+                        bottom: 0,
+                        height: 2,
+                        backgroundColor: '#00EF8B',
+                        width: activeWidth,
+                        left: activeLeft,
+                      }}
+                    />
                     <li
                       className={`${
                         activeTabMap['proposals'] ? 'is-active' : ''
                       }`}
                     >
                       <Tablink
+                        ref={proposalRef}
                         linkText="Proposals"
                         linkUrl={`/community/${community.id}?tab=proposals`}
                         isActive={activeTabMap['proposals']}
@@ -352,6 +393,7 @@ export default function Community() {
                       }`}
                     >
                       <Tablink
+                        ref={memberRef}
                         linkText="Members"
                         linkUrl={`/community/${community.id}?tab=members`}
                         isActive={activeTabMap['members']}
@@ -362,6 +404,7 @@ export default function Community() {
                       className={`${activeTabMap['about'] ? 'is-active' : ''}`}
                     >
                       <Tablink
+                        ref={aboutRef}
                         linkText="About"
                         linkUrl={`/community/${community.id}?tab=about`}
                         isActive={activeTabMap['about']}


### PR DESCRIPTION
Animates the "active" underline underneath a navigation tab on the community page similar to https://codepen.io/everdimension/pen/xZLggo but with support for dynamic tab link widths / positions.