### PR TITLE
CAS-281: Fix broken test

### DIFF
--- a/backend/main/community_user_test.go
+++ b/backend/main/community_user_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"net/http"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/DapperCollectives/CAST/backend/main/models"
@@ -145,8 +147,11 @@ func TestGetUserCommunities(t *testing.T) {
 	var p test_utils.PaginatedResponseWithUserCommunity
 	json.Unmarshal(response.Body.Bytes(), &p)
 
+	roles := strings.Split(p.Data[0].Roles, ",")
+	sort.Strings(roles)
+
 	assert.Equal(t, 1, p.TotalRecords)
-	assert.Equal(t, "member,author,admin", p.Data[0].Roles)
+	assert.Equal(t, "admin,author,member", strings.Join(roles, ","))
 }
 
 func TestDeleteUserFromCommunity(t *testing.T) {


### PR DESCRIPTION
**Ticket:** [CAS-281](https://linear.app/dappercollectives/issue/CAS-281/failing-test-on-main-branch)

**Description:**

- order of values returned for roles in TestGetUserCommunities is not consistent, sorted values to ensure test passes while checking for expected roles.