### PR TITLE
CAS-315: Fix Leaderboard showing current user if on leaderboard

### DIFF
--- a/frontend/packages/client/src/components/LeaderBoard.js
+++ b/frontend/packages/client/src/components/LeaderBoard.js
@@ -29,6 +29,11 @@ const LeaderBoard = ({
   const { data, isLoading } = useLeaderBoard({ communityId, addr: user?.addr });
   const style = {};
 
+  const showCurrentUser =
+    !isLoading &&
+    data?.users &&
+    data.users.find(({ addr }) => addr === user?.addr) === -1;
+
   return (
     <div className="is-flex is-flex-direction-column">
       <WrapperResponsive
@@ -80,7 +85,7 @@ const LeaderBoard = ({
             })}
         </tbody>
       </table>
-      {!isLoading && data?.currentUser && (
+      {showCurrentUser && (
         <table className="table is-fullwidth">
           <tbody className="is-scrollable-table" style={style}>
             <Row


### PR DESCRIPTION
**Ticket:** [CAS-315](https://linear.app/dappercollectives/issue/CAS-315/leaderboard-populates-duplicate-addresses)

**Description:**

- Current User was being displayed when present in Leaderboard. Updated logic to check if user exists on leaderboard and only displays user if they are not already on the leaderboard.