### PR TITLE
CAS-291: Add Link to getting started guide on Strategy Selector

### DIFF
--- a/frontend/packages/client/src/components/Community/StrategyEditorModal/StrategyInformationForm.js
+++ b/frontend/packages/client/src/components/Community/StrategyEditorModal/StrategyInformationForm.js
@@ -18,6 +18,16 @@ export default function StrategyInformationForm({
   return (
     <>
       <div className="columns is-flex-direction-column is-mobile m-0">
+        <div className="small-text" style={{ color: '#757575' }}>
+          Need help finding this information?{' '}
+          <a
+            href="https://docs.cast.fyi"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Check our Getting Started Guide.
+          </a>
+        </div>
         {formFields.map((field, index) => (
           <Input
             key={index}

--- a/frontend/packages/client/src/components/Community/StrategyEditorModal/index.js
+++ b/frontend/packages/client/src/components/Community/StrategyEditorModal/index.js
@@ -3,7 +3,7 @@ import networks from 'networks';
 import StrategySelector from './StrategySelector';
 import StrategyInformationForm from './StrategyInformationForm';
 import { ActionButton } from 'components';
-import { isValidAddress } from 'utils';
+import { isValidAddress, kebabToString } from 'utils';
 
 const networkConfig = networks[process.env.REACT_APP_FLOW_ENV];
 
@@ -112,7 +112,11 @@ export default function StrategyEditorModal({
         style={{ borderBottom: 'none' }}
       >
         <div className="column p-0 is-flex flex-1">
-          <h2 className="is-size-4">Select a Strategy</h2>
+          <h2 className="is-size-4" style={{ textTransform: 'capitalize' }}>
+            {step === ModalSteps[2] && strategyData?.name
+              ? kebabToString(strategyData.name)
+              : 'Select a Strategy'}
+          </h2>
         </div>
         <div
           className={`column is-narrow px-0 has-text-right is-size-2 leading-tight cursor-pointer ${


### PR DESCRIPTION
**Ticket:** [CAS-291](https://linear.app/dappercollectives/issue/CAS-291/update-strategy-selector-modal-step)

**Description:**

- Adds Strategy name to the title of the information modal.
- Adds text for linking to Getting Started guide. Temporarily links to https://docs.cast.fyi since Getting Started Guide is not completed yet.

<img width="751" alt="Screen Shot 2022-07-22 at 3 40 01 PM" src="https://user-images.githubusercontent.com/22734700/180577392-9b77f775-ac2c-4ef2-a2ee-c9aa6398eb43.png">


