### PR TITLE
Main -> Staging (One Address One Vote)

### DIFF
--- a/backend/main/server/app.go
+++ b/backend/main/server/app.go
@@ -66,7 +66,7 @@ type Strategy interface {
 	TallyVotes(votes []*models.VoteWithBalance, p *models.ProposalResults) (models.ProposalResults, error)
 	GetVotes(votes []*models.VoteWithBalance, proposal *models.Proposal) ([]*models.VoteWithBalance, error)
 	GetVoteWeightForBalance(vote *models.VoteWithBalance, proposal *models.Proposal) (float64, error)
-	InitStrategy(f *shared.FlowAdapter, db *shared.Database, sc *shared.SnapshotClient)
+	InitStrategy(f *shared.FlowAdapter, db *shared.Database, sc *shared.SnapshotClient, name string)
 	FetchBalance(b *models.Balance, p *models.Proposal) (*models.Balance, error)
 	RequiresSnapshot() bool
 }
@@ -75,6 +75,8 @@ var strategyMap = map[string]Strategy{
 	"token-weighted-default":        &strategies.TokenWeightedDefault{},
 	"staked-token-weighted-default": &strategies.StakedTokenWeightedDefault{},
 	"one-address-one-vote":          &strategies.OneAddressOneVote{},
+	"one-address-one-vote-ft":       &strategies.OneAddressOneVote{},
+	"one-address-one-vote-nft":      &strategies.OneAddressOneVote{},
 	"balance-of-nfts":               &strategies.BalanceOfNfts{},
 }
 
@@ -322,7 +324,7 @@ func (a *App) getResultsForProposal(w http.ResponseWriter, r *http.Request) {
 	}
 
 	proposalWithChoices := models.NewProposalResults(proposalId, p.Choices)
-	s.InitStrategy(a.FlowAdapter, a.DB, a.SnapshotClient)
+	s.InitStrategy(a.FlowAdapter, a.DB, a.SnapshotClient, *p.Strategy)
 
 	proposalResults, err := s.TallyVotes(votes, proposalWithChoices)
 	if err != nil {
@@ -379,7 +381,7 @@ func (a *App) getVotesForProposal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.InitStrategy(a.FlowAdapter, a.DB, a.SnapshotClient)
+	s.InitStrategy(a.FlowAdapter, a.DB, a.SnapshotClient, *proposal.Strategy)
 
 	votes, totalRecords, err := models.GetVotesForProposal(a.DB, start, count, order, proposalId, *proposal.Strategy)
 	if err != nil {
@@ -590,7 +592,7 @@ func (a *App) createVoteForProposal(w http.ResponseWriter, r *http.Request) {
 		respondWithError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	// validate user signature
+	// validate transaction signature
 	// if err := a.FlowAdapter.UserTransactionValidate(v.Addr, v.Message, v.Composite_signatures, v.TransactionId, a.TxOptionsAddresses, p.Choices); err != nil {
 	// 	respondWithError(w, http.StatusBadRequest, err.Error())
 	// 	return
@@ -612,7 +614,7 @@ func (a *App) createVoteForProposal(w http.ResponseWriter, r *http.Request) {
 		emptyBalance.BlockHeight = *p.Block_height
 	}
 
-	s.InitStrategy(a.FlowAdapter, a.DB, a.SnapshotClient)
+	s.InitStrategy(a.FlowAdapter, a.DB, a.SnapshotClient, *p.Strategy)
 
 	balance, err := s.FetchBalance(emptyBalance, &p)
 	if err != nil {
@@ -795,7 +797,7 @@ func (a *App) createProposal(w http.ResponseWriter, r *http.Request) {
 
 	}
 	s := strategyMap[*p.Strategy]
-	s.InitStrategy(a.FlowAdapter, a.DB, a.SnapshotClient)
+	s.InitStrategy(a.FlowAdapter, a.DB, a.SnapshotClient, *p.Strategy)
 
 	var snapshotResponse *shared.SnapshotResponse
 	if s.RequiresSnapshot() {

--- a/backend/main/strategies/balance_of_nfts.go
+++ b/backend/main/strategies/balance_of_nfts.go
@@ -4,62 +4,20 @@ import (
 	"github.com/DapperCollectives/CAST/backend/main/models"
 	"github.com/DapperCollectives/CAST/backend/main/shared"
 	s "github.com/DapperCollectives/CAST/backend/main/shared"
-	"github.com/rs/zerolog/log"
 )
 
 type BalanceOfNfts struct {
 	s.StrategyStruct
 	SC s.SnapshotClient
 	DB *s.Database
+	name string
 }
 
 func (b *BalanceOfNfts) FetchBalance(
 	balance *models.Balance,
 	p *models.Proposal,
 ) (*models.Balance, error) {
-
-	v := models.Vote{Proposal_id: balance.Proposal_id, Addr: balance.Addr}
-	vb := &models.VoteWithBalance{
-		NFTs: []*models.NFT{},
-		Vote: v,
-	}
-
-	var c models.Community
-	if err := c.GetCommunityByProposalId(b.DB, balance.Proposal_id); err != nil {
-		return nil, err
-	}
-
-	strategy, err := models.MatchStrategyByProposal(*c.Strategies, *p.Strategy)
-	if err != nil {
-		log.Error().Err(err).Msg("Unable to find strategy for contract.")
-		return nil, err
-	}
-
-	nftIds, err := b.FlowAdapter.GetNFTIds(balance.Addr, &strategy.Contract)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, nftId := range nftIds {
-		nft := &models.NFT{
-			ID: nftId,
-		}
-		vb.NFTs = append(vb.NFTs, nft)
-	}
-
-	doesExist, err := models.DoesNFTExist(b.DB, vb)
-	if err != nil {
-		return nil, err
-	}
-
-	//only if the NFT ID is not already in the DB,
-	//do we add the balance
-	if !doesExist && err == nil {
-		err = models.CreateUserNFTRecord(b.DB, vb)
-		balance.NFTCount = len(vb.NFTs)
-	}
-
-	return balance, nil
+	return FetchNFTBalance(b.DB, b.FlowAdapter, balance, p)
 }
 
 func (b *BalanceOfNfts) TallyVotes(
@@ -104,8 +62,10 @@ func (s *BalanceOfNfts) InitStrategy(
 	f *shared.FlowAdapter,
 	db *shared.Database,
 	sc *s.SnapshotClient,
+	name string,
 ) {
 	s.FlowAdapter = f
 	s.DB = db
 	s.SC = *sc
+	s.name = name
 }

--- a/backend/main/strategies/one_address_one_vote.go
+++ b/backend/main/strategies/one_address_one_vote.go
@@ -14,6 +14,7 @@ type OneAddressOneVote struct {
 	s.StrategyStruct
 	SC s.SnapshotClient
 	DB *s.Database
+	name string
 }
 
 func (s *OneAddressOneVote) FetchBalance(
@@ -21,19 +22,26 @@ func (s *OneAddressOneVote) FetchBalance(
 	p *models.Proposal,
 ) (*models.Balance, error) {
 
-	if err := b.GetBalanceByAddressAndBlockHeight(s.DB); err != nil && err.Error() != pgx.ErrNoRows.Error() {
-		log.Error().Err(err).Msg("Error querying address b at blockheight.")
-		return nil, err
-	}
-
-	if b.ID == "" {
-		if err := b.CreateBalance(s.DB); err != nil {
-			log.Error().Err(err).Msg("Error saving b to database.")
+	if s.name == "one-address-one-vote-nft" {
+		return FetchNFTBalance(s.DB, s.FlowAdapter, b, p)
+	} else if s.name == "one-address-one-vote-ft" {
+		return FetchFTBalance(s.DB, s.SC, b, p)
+	} else {
+		// DEPRECATED: original one-address-one-vote balance implementation before NFT/FT restrictions were introduced
+		if err := b.GetBalanceByAddressAndBlockHeight(s.DB); err != nil && err.Error() != pgx.ErrNoRows.Error() {
+			log.Error().Err(err).Msg("error querying address b at blockheight")
 			return nil, err
 		}
+	
+		if b.ID == "" {
+			if err := b.CreateBalance(s.DB); err != nil {
+				log.Error().Err(err).Msg("error saving b to DB")
+				return nil, err
+			}
+		}
+	
+		return b, nil
 	}
-
-	return b, nil
 }
 
 func (s *OneAddressOneVote) TallyVotes(
@@ -87,8 +95,10 @@ func (s *OneAddressOneVote) InitStrategy(
 	f *shared.FlowAdapter,
 	db *shared.Database,
 	sc *s.SnapshotClient,
+	name string,
 ) {
 	s.FlowAdapter = f
 	s.DB = db
 	s.SC = *sc
+	s.name = name
 }

--- a/backend/main/strategies/staked_token_weighted_default.go
+++ b/backend/main/strategies/staked_token_weighted_default.go
@@ -14,6 +14,7 @@ type StakedTokenWeightedDefault struct {
 	s.StrategyStruct
 	SC s.SnapshotClient
 	DB *s.Database
+	name string
 }
 
 func (s *StakedTokenWeightedDefault) FetchBalance(
@@ -117,8 +118,10 @@ func (s *StakedTokenWeightedDefault) InitStrategy(
 	f *shared.FlowAdapter,
 	db *shared.Database,
 	sc *s.SnapshotClient,
+	name string,
 ) {
 	s.FlowAdapter = f
 	s.DB = db
 	s.SC = *sc
+	s.name = name
 }

--- a/backend/main/strategies/token_weighted_default.go
+++ b/backend/main/strategies/token_weighted_default.go
@@ -16,6 +16,7 @@ type TokenWeightedDefault struct {
 	s.StrategyStruct
 	SC s.SnapshotClient
 	DB *s.Database
+	name string
 }
 
 type FTBalanceResponse struct {
@@ -138,8 +139,10 @@ func (s *TokenWeightedDefault) InitStrategy(
 	f *shared.FlowAdapter,
 	db *shared.Database,
 	sc *s.SnapshotClient,
+	name string,
 ) {
 	s.FlowAdapter = f
 	s.DB = db
 	s.SC = *sc
+	s.name = name
 }

--- a/backend/main/strategies/utils.go
+++ b/backend/main/strategies/utils.go
@@ -1,0 +1,98 @@
+package strategies
+
+import (
+	"github.com/DapperCollectives/CAST/backend/main/models"
+	s "github.com/DapperCollectives/CAST/backend/main/shared"
+	"github.com/jackc/pgx/v4"
+	"github.com/rs/zerolog/log"
+)
+
+func FetchNFTBalance(
+	db *s.Database,
+	fa *s.FlowAdapter,
+	balance *models.Balance,
+	p *models.Proposal,
+) (*models.Balance, error) {
+
+	vb := &models.VoteWithBalance{
+		NFTs: []*models.NFT{},
+	}
+
+	var c models.Community
+	if err := c.GetCommunityByProposalId(db, balance.Proposal_id); err != nil {
+		return nil, err
+	}
+
+	strategy, err := models.MatchStrategyByProposal(*c.Strategies, *p.Strategy)
+	if err != nil {
+		log.Error().Err(err).Msg("Unable to find strategy for contract")
+		return nil, err
+	}
+
+	nftIds, err := fa.GetNFTIds(balance.Addr, &strategy.Contract)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, nftId := range nftIds {
+		nft := &models.NFT{
+			ID: nftId,
+		}
+		vb.NFTs = append(vb.NFTs, nft)
+	}
+
+	doesExist, err := models.DoesNFTExist(db, vb)
+	if err != nil {
+		return nil, err
+	}
+
+	//only if the NFT ID is not already in the DB,
+	//do we add the balance
+	if !doesExist && err == nil {
+		err = models.CreateUserNFTRecord(db, vb)
+		balance.NFTCount = len(vb.NFTs)
+	}
+
+	return balance, nil
+}
+
+func FetchFTBalance(
+	db *s.Database,
+	sc s.SnapshotClient,
+	b *models.Balance,
+	p *models.Proposal,
+) (*models.Balance, error) {
+
+	var c models.Community
+	if err := c.GetCommunityByProposalId(db, b.Proposal_id); err != nil {
+		return nil, err
+	}
+
+	if err := b.GetBalanceByAddressAndBlockHeight(db); err != nil && err.Error() != pgx.ErrNoRows.Error() {
+		log.Error().Err(err).Msg("error fetching balance from DB")
+		return nil, err
+	}
+
+	strategy, err := models.MatchStrategyByProposal(*c.Strategies, *p.Strategy)
+	if err != nil {
+		log.Error().Err(err).Msg("Unable to find strategy for contract")
+		return nil, err
+	}
+
+	if err := sc.GetAddressBalanceAtBlockHeight(
+		b.Addr,
+		b.BlockHeight,
+		b,
+		&strategy.Contract,
+	); err != nil {
+		log.Error().Err(err).Msg("error fetching balance")
+		return nil, err
+	}
+
+	if err := b.CreateBalance(db); err != nil {
+		log.Error().Err(err).Msg("error creating balance in the DB")
+		return nil, err
+	}
+
+	return b, nil
+}

--- a/backend/main/strategies_test.go
+++ b/backend/main/strategies_test.go
@@ -353,3 +353,186 @@ func TestOneTokenOneVoteStrategy(t *testing.T) {
 		}
 	})
 }
+
+/* One Address One Vote NFT */
+func TestOneTokenOneVoteNFTStrategy(t *testing.T) {
+	clearTable("communities")
+	clearTable("community_users")
+	clearTable("proposals")
+	clearTable("votes")
+	clearTable("balances")
+	clearTable("nfts")
+
+	communityId, community := otu.AddCommunitiesWithNFTContract(1, "user1")
+	proposalIds, proposals := otu.AddProposalsForStrategy(communityId[0], "one-address-one-vote-nft", 1)
+	proposalId := proposalIds[0]
+	choices := proposals[0].Choices
+
+	var contract = &shared.Contract{
+		Name: community.Contract_name,
+		Addr: community.Contract_addr,
+	}
+
+	votes, err := otu.GenerateListOfVotesWithNFTs(proposalId, 5, contract)
+	if err != nil {
+		t.Error(err)
+	}
+
+	otu.AddDummyVotesAndNFTs(votes)
+	t.Run("Test Tallying Results For One Address One Vote NFT Strategy", func(t *testing.T) {
+
+		proposalWithChoices := models.NewProposalResults(proposalId, choices)
+		_results := otu.TallyResultsForBalanceOfNfts(votes, proposalWithChoices)
+
+		response := otu.GetProposalResultsAPI(proposalId)
+		CheckResponseCode(t, http.StatusOK, response.Code)
+
+		var results models.ProposalResults
+		json.Unmarshal(response.Body.Bytes(), &results)
+
+		assert.Equal(t, _results.Proposal_id, results.Proposal_id)
+		assert.Equal(t, _results.Results_float["a"], results.Results_float["a"])
+		assert.Equal(t, _results.Results_float["b"], results.Results_float["b"])
+	})
+
+	t.Run("Test Fetching Votes for Proposal", func(t *testing.T) {
+		response := otu.GetVotesForProposalAPI(proposalId)
+		CheckResponseCode(t, http.StatusOK, response.Code)
+
+		var body utils.PaginatedResponseWithVotes
+		json.Unmarshal(response.Body.Bytes(), &body)
+
+		// Validate vote weights are returned correctly
+		for _, v := range body.Data {
+			expectedWeight := float64(1.00)
+			assert.Equal(t, expectedWeight, *v.Weight)
+		}
+	})
+
+	t.Run("Test Fetching Vote for Address", func(t *testing.T) {
+		_vote := (*votes)[0]
+		response := otu.GetVoteForProposalByAddressAPI(proposalId, _vote.Addr)
+
+		CheckResponseCode(t, http.StatusOK, response.Code)
+
+		var vote models.VoteWithBalance
+		json.Unmarshal(response.Body.Bytes(), &vote)
+
+		expectedWeight := float64(1.00)
+		assert.Equal(t, expectedWeight, *vote.Weight)
+	})
+
+	t.Run("Attempt to cheat the NFT strategy", func(t *testing.T) {
+		proposalWithChoices := models.NewProposalResults(proposalId, choices)
+		_ = otu.TallyResultsForBalanceOfNfts(votes, proposalWithChoices)
+
+		response := otu.GetProposalResultsAPI(proposalId)
+		CheckResponseCode(t, http.StatusOK, response.Code)
+
+		var correctResults models.ProposalResults
+		json.Unmarshal(response.Body.Bytes(), &correctResults)
+
+		otu.SetupAccountForNFTs("user6")
+		otu.TransferNFT("user2", "user3", 1)
+
+		cheatVote, err := otu.GenerateSingleVoteWithNFT(proposalId, 3, contract)
+		if err != nil {
+			t.Error(err)
+		}
+		votesWithCheat := append(*votes, *cheatVote)
+		cheatResults := otu.TallyResultsForBalanceOfNfts(&votesWithCheat, proposalWithChoices)
+
+		response = otu.GetProposalResultsAPI(proposalId)
+		CheckResponseCode(t, http.StatusOK, response.Code)
+
+		json.Unmarshal(response.Body.Bytes(), &cheatResults)
+
+		//weight should be the same as before the cheat vote was added
+		//because the cheat vote should be ignored by the server
+		//therefore the cheatResults should be the same as the correctResults
+
+		assert.Equal(t, correctResults.Proposal_id, cheatResults.Proposal_id)
+		assert.Equal(t, correctResults.Results_float["a"], cheatResults.Results_float["a"])
+		assert.Equal(t, correctResults.Results_float["b"], cheatResults.Results_float["b"])
+	})
+}
+
+/* One Token One Vote FT */
+func TestOneTokenOneVoteFTStrategy(t *testing.T) {
+	clearTable("communities")
+	clearTable("community_users")
+	clearTable("proposals")
+	clearTable("votes")
+	clearTable("balances")
+
+	communityId := otu.AddCommunities(1)[0]
+	proposalIds, proposals := otu.AddProposalsForStrategy(communityId, "one-address-one-vote-ft", 2)
+	votes := otu.GenerateListOfVotes(proposalIds[0], 10)
+	proposalId := proposalIds[0]
+	proposalIdTwo := proposalIds[1]
+	choices := proposals[0].Choices
+
+	otu.AddDummyVotesAndBalances(votes)
+
+	t.Run("Test Tallying Results", func(t *testing.T) {
+		// Tally results
+
+		proposalWithChoices := models.NewProposalResults(proposalId, choices)
+		_results := otu.TallyResultsForOneAddressOneVote(votes, proposalWithChoices)
+
+		// Fetch Proposal Results
+		response := otu.GetProposalResultsAPI(proposalIds[0])
+		CheckResponseCode(t, http.StatusOK, response.Code)
+
+		var results models.ProposalResults
+		json.Unmarshal(response.Body.Bytes(), &results)
+
+		assert.Equal(t, _results.Proposal_id, results.Proposal_id)
+		assert.Equal(t, _results.Results_float["a"], results.Results_float["a"])
+		assert.Equal(t, _results.Results_float["b"], results.Results_float["b"])
+	})
+
+	t.Run("Test Fetching Votes for Proposal", func(t *testing.T) {
+		response := otu.GetVotesForProposalAPI(proposalId)
+
+		CheckResponseCode(t, http.StatusOK, response.Code)
+
+		var body utils.PaginatedResponseWithVotes
+		json.Unmarshal(response.Body.Bytes(), &body)
+
+		// Validate vote weights are returned correctly
+		for _, v := range body.Data {
+			expectedWeight := 1.00
+			assert.Equal(t, &expectedWeight, v.Weight)
+		}
+	})
+
+	t.Run("Test Fetching Vote for Address", func(t *testing.T) {
+		_vote := (*votes)[0]
+		response := otu.GetVoteForProposalByAddressAPI(proposalId, _vote.Addr)
+
+		CheckResponseCode(t, http.StatusOK, response.Code)
+
+		var vote models.VoteWithBalance
+		json.Unmarshal(response.Body.Bytes(), &vote)
+
+		_expectedWeight := 1.00
+		assert.Equal(t, _expectedWeight, *vote.Weight)
+	})
+
+	t.Run("Test Fetching Votes For Address", func(t *testing.T) {
+		_vote := (*votes)[0]
+		proposalIds := []int{proposalId, proposalIdTwo}
+
+		response := otu.GetVotesForAddressAPI(_vote.Addr, proposalIds)
+		CheckResponseCode(t, http.StatusOK, response.Code)
+
+		var votes []models.VoteWithBalance
+		json.Unmarshal(response.Body.Bytes(), &votes)
+
+		for _, v := range votes {
+			_expectedWeight := 1.00
+			assert.Equal(t, _expectedWeight, *v.Weight)
+		}
+	})
+}

--- a/backend/migrations/000029_add_one_address_nft_ft_strategy.down.sql
+++ b/backend/migrations/000029_add_one_address_nft_ft_strategy.down.sql
@@ -1,0 +1,8 @@
+DELETE FROM voting_strategies WHERE key='one-address-one-vote-nft';
+DELETE FROM voting_strategies WHERE key='one-address-one-vote-ft';
+
+-- Remove values from enum
+DELETE FROM pg_enum WHERE oid IN (
+    SELECT oid FROM pg_enum where enumLabel='one-address-one-vote-nft' OR enumLabel='one-address-one-vote-ft'
+);
+

--- a/backend/migrations/000029_add_one_address_nft_ft_strategy.up.sql
+++ b/backend/migrations/000029_add_one_address_nft_ft_strategy.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+ALTER TYPE strategies ADD VALUE IF NOT EXISTS 'one-address-one-vote-nft';
+ALTER TYPE strategies ADD VALUE IF NOT EXISTS 'one-address-one-vote-ft';
+END TRANSACTION;
+COMMIT;
+
+INSERT INTO voting_strategies (key, name, description)
+VALUES ('one-address-one-vote-nft', 'One Address One Vote (NFT)', 'A wallet address vote counts as one vote as long as it has at least one NFT that matches the contract of the proposal.');
+INSERT INTO voting_strategies (key, name, description)
+VALUES ('one-address-one-vote-ft', 'One Address One Vote (FT)', 'A wallet address vote counts as one vote as long as it has at least one fungible token that matches the contract of the proposal.');

--- a/frontend/packages/client/src/components/Community/StrategyEditorModal/index.js
+++ b/frontend/packages/client/src/components/Community/StrategyEditorModal/index.js
@@ -1,26 +1,59 @@
 import React, { useEffect, useState } from 'react';
-import networks from 'networks';
 import StrategySelector from './StrategySelector';
 import StrategyInformationForm from './StrategyInformationForm';
 import { ActionButton } from 'components';
 import { isValidAddress } from 'utils';
-
-const networkConfig = networks[process.env.REACT_APP_FLOW_ENV];
 
 const ModalSteps = {
   1: 'select-strategy',
   2: 'strategy-information',
 };
 
-const initialFormFields = {
-  addr: '',
-  name: '',
-  threshold: '',
-  maxWeight: '',
-  publicPath: '',
+const getFormFields = (strategyName) => {
+  let initialFormFields = {
+    addr: '',
+    name: '',
+    threshold: '',
+    maxWeight: '',
+    publicPath: '',
+  };
+
+  if (
+    strategyName === 'one-address-one-vote-nft' ||
+    strategyName === 'one-address-one-vote-ft'
+  ) {
+    initialFormFields = {
+      addr: '',
+      name: '',
+      publicPath: '',
+    };
+  }
+  return Object.keys(initialFormFields);
 };
 
-const formFields = Object.keys(initialFormFields);
+const getRequiredFields = (strategyName) => {
+  let requiredFields = {
+    addr: (addr) => addr?.trim().length > 0 && isValidAddress(addr),
+    name: (name) => name?.trim().length > 0 && name?.trim().length <= 150,
+    publicPath: (path) => path?.trim().length > 0 && path?.trim().length <= 150,
+    maxWeight: (maxWeight) =>
+      maxWeight?.trim().length > 0 && /^[0-9]+$/.test(maxWeight),
+    threshold: (threshold) =>
+      threshold?.trim().length > 0 && /^[0-9]+$/.test(threshold),
+  };
+  if (
+    strategyName === 'one-address-one-vote-nft' ||
+    strategyName === 'one-address-one-vote-ft'
+  ) {
+    requiredFields = {
+      addr: (addr) => addr?.trim().length > 0 && isValidAddress(addr),
+      name: (name) => name?.trim().length > 0 && name?.trim().length <= 150,
+      publicPath: (path) =>
+        path?.trim().length > 0 && path?.trim().length <= 150,
+    };
+  }
+  return requiredFields;
+};
 
 export default function StrategyEditorModal({
   strategies = [],
@@ -37,21 +70,12 @@ export default function StrategyEditorModal({
 
   const [strategyData, setStrategyData] = useState({
     name: '',
-    contract: { ...initialFormFields },
+    contract: {},
   });
 
   // this useEffect validates form on second step
   useEffect(() => {
-    const requiredFields = {
-      addr: (addr) => addr?.trim().length > 0 && isValidAddress(addr),
-      name: (name) => name?.trim().length > 0 && name?.trim().length <= 150,
-      publicPath: (path) =>
-        path?.trim().length > 0 && path?.trim().length <= 150,
-      maxWeight: (maxWeight) =>
-        maxWeight?.trim().length > 0 && /^[0-9]+$/.test(maxWeight),
-      threshold: (threshold) =>
-        threshold?.trim().length > 0 && /^[0-9]+$/.test(threshold),
-    };
+    const requiredFields = getRequiredFields(strategyData.name);
     const isValid = Object.keys(requiredFields).every((field) =>
       requiredFields[field](strategyData.contract[field])
     );
@@ -60,26 +84,6 @@ export default function StrategyEditorModal({
 
   // user selected strategy move to second step to enter information
   const setStrategy = (strategyName) => {
-    //
-    // STRATEGY CONFIGURATION
-    //
-    // If strategy selected is 'one-address-one-vote'
-    // then no more information is required(FE uses strategy configuration)
-    // modal should be closed and strategy should be ready to be added
-    if (strategyName === 'one-address-one-vote') {
-      const strategyConfig =
-        networkConfig.strategiesConfig['one-address-one-vote'];
-      onDone({
-        name: strategyName,
-        contract: {
-          name: strategyConfig.name,
-          addr: strategyConfig.addr,
-          publicPath: strategyConfig.publicPath,
-          threshold: '0',
-        },
-      });
-      return;
-    }
     setStrategyData((state) => ({ ...state, name: strategyName }));
     // else go to second step
     setSep(ModalSteps[2]);
@@ -147,7 +151,7 @@ export default function StrategyEditorModal({
           <StrategyInformationForm
             setField={setContractInfoField}
             formData={strategyData.contract}
-            formFields={formFields}
+            formFields={getFormFields(strategyData.name)}
             actionButton={
               <ActionButton
                 label="done"

--- a/frontend/packages/client/src/hooks/useVotingStrategies.js
+++ b/frontend/packages/client/src/hooks/useVotingStrategies.js
@@ -11,7 +11,19 @@ export default function useVotingStrategies() {
     const url = `${process.env.REACT_APP_BACK_END_SERVER_API}/voting-strategies`;
     try {
       const response = await fetch(url);
-      const strategies = await checkResponse(response);
+      let strategies = await checkResponse(response);
+      // If nft/ft strategies exist for one-address-one-vote, remove one-address-one-vote as an option as it is deprecated
+      if (
+        strategies.filter(
+          (strategy) =>
+            strategy.key === 'one-address-one-vote-nft' ||
+            strategy.key === 'one-address-one-vote-ft'
+        ).length === 2
+      ) {
+        strategies = strategies.filter(
+          (strategy) => strategy.key !== 'one-address-one-vote'
+        );
+      }
       dispatch({ type: 'SUCCESS', payload: strategies });
     } catch (err) {
       notifyError(err, url);


### PR DESCRIPTION
* updated makeFile and flow.json

* updated float import paths

* updated flow nft contracts

* updated flow nfts contracts to latest versions

* CAS-204: Add FE changes for One Address One Vote information

* CAS-204: Add BE changes for One Address One Vote restrictions

* updated the ExampleNFT flow to run successfuly on emulator

* fixed issue with GetVoteWeightForBalance balance_of_nfts

* added flow contracts and updated Makefile

* updated cadence script for new ExampleNFT

* created processThreshold logic

* updated NFT ID to type interface to handle string or uint

* clean up

* handle nft balance return type in EnforceToken

* overflow breaking changes fixes

* added in wrongly deleted make command

* updated NFT Test

* updated Makefile

* CAS-204: Add NFT/FT restrictions to One Address One Vote strategies

* CAS-204: Fix strategy display text and migration file bug

* CAS-204: Update descriptions for one address one vote nft/ft

Co-authored-by: Richard Melkonian <r.v.melkonian@gmail.com>
Co-authored-by: Jonathan Bluks <jonathan.bluks@dapperlabs.com>