### PR TITLE
add configuration to use local emulator

### DIFF
--- a/frontend/packages/client/src/components/WalletConnectModal.js
+++ b/frontend/packages/client/src/components/WalletConnectModal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import { ArrowRight, Close } from './Svg';
+import { IS_LOCAL_DEV } from 'const';
 
 export default function WalletConnectModal({
   services = [],
@@ -8,8 +9,6 @@ export default function WalletConnectModal({
   closeModal,
   injectedProvider,
 } = {}) {
-  const isLocalDev = process.env.REACT_APP_FLOW_ENV === 'emulator';
-
   const modalClasses = classnames('modal', {
     'is-active': openModal,
   });
@@ -20,7 +19,7 @@ export default function WalletConnectModal({
 
   const listOfServices = services.map((service) => ({
     connectToService: () => {
-      injectedProvider.authenticate(!isLocalDev ? { service } : undefined);
+      injectedProvider.authenticate(!IS_LOCAL_DEV ? { service } : undefined);
       closeModal();
     },
     icon: `https://fcl-discovery.onflow.org${service.provider.icon}`,

--- a/frontend/packages/client/src/components/WalletConnectModal.js
+++ b/frontend/packages/client/src/components/WalletConnectModal.js
@@ -8,6 +8,8 @@ export default function WalletConnectModal({
   closeModal,
   injectedProvider,
 } = {}) {
+  const isLocalDev = process.env.REACT_APP_FLOW_ENV === 'emulator';
+
   const modalClasses = classnames('modal', {
     'is-active': openModal,
   });
@@ -18,7 +20,7 @@ export default function WalletConnectModal({
 
   const listOfServices = services.map((service) => ({
     connectToService: () => {
-      injectedProvider.authenticate({ service });
+      injectedProvider.authenticate(!isLocalDev ? { service } : undefined);
       closeModal();
     },
     icon: `https://fcl-discovery.onflow.org${service.provider.icon}`,

--- a/frontend/packages/client/src/const/index.js
+++ b/frontend/packages/client/src/const/index.js
@@ -5,6 +5,8 @@ export const MAX_AVATAR_FILE_SIZE = 2097152;
 
 export const MAX_PROPOSAL_IMAGE_FILE_SIZE = 2097152;
 
+export const IS_LOCAL_DEV = process.env.REACT_APP_FLOW_ENV !== 'emulator';
+
 export const FilterValues = {
   all: 'All',
   active: 'Active',

--- a/frontend/packages/client/src/const/index.js
+++ b/frontend/packages/client/src/const/index.js
@@ -5,7 +5,7 @@ export const MAX_AVATAR_FILE_SIZE = 2097152;
 
 export const MAX_PROPOSAL_IMAGE_FILE_SIZE = 2097152;
 
-export const IS_LOCAL_DEV = process.env.REACT_APP_FLOW_ENV !== 'emulator';
+export const IS_LOCAL_DEV = process.env.REACT_APP_FLOW_ENV === 'emulator';
 
 export const FilterValues = {
   all: 'All',

--- a/frontend/packages/client/src/contexts/Web3.js
+++ b/frontend/packages/client/src/contexts/Web3.js
@@ -78,7 +78,7 @@ export function Web3Provider({ children, network = 'testnet', ...props }) {
 
   // filter services for now only blocto
   useEffect(() => {
-    if (IS_LOCAL_DEV) {
+    if (!IS_LOCAL_DEV) {
       fcl.discovery.authn.subscribe((res) => {
         const filteredServices = res.results.filter((service) =>
           service.uid.includes('blocto')

--- a/frontend/packages/client/src/contexts/Web3.js
+++ b/frontend/packages/client/src/contexts/Web3.js
@@ -3,6 +3,7 @@ import * as fcl from '@onflow/fcl';
 import networks from 'networks';
 import { useFclUser } from 'hooks';
 import { WalletConnectModal } from 'components';
+import { IS_LOCAL_DEV } from 'const';
 
 // create our app context
 export const Web3Context = React.createContext({});
@@ -77,7 +78,7 @@ export function Web3Provider({ children, network = 'testnet', ...props }) {
 
   // filter services for now only blocto
   useEffect(() => {
-    if (process.env.REACT_APP_FLOW_ENV !== 'emulator') {
+    if (IS_LOCAL_DEV) {
       fcl.discovery.authn.subscribe((res) => {
         const filteredServices = res.results.filter((service) =>
           service.uid.includes('blocto')

--- a/frontend/packages/client/src/contexts/Web3.js
+++ b/frontend/packages/client/src/contexts/Web3.js
@@ -85,7 +85,8 @@ export function Web3Provider({ children, network = 'testnet', ...props }) {
         setServices(filteredServices);
       });
     } else {
-      // hard code service for local dev
+      // hard code service for local dev wallet
+      // this setting will enable to show blocto to connect
       setServices([
         {
           f_type: 'Service',

--- a/frontend/packages/client/src/contexts/Web3.js
+++ b/frontend/packages/client/src/contexts/Web3.js
@@ -77,12 +77,29 @@ export function Web3Provider({ children, network = 'testnet', ...props }) {
 
   // filter services for now only blocto
   useEffect(() => {
-    fcl.discovery.authn.subscribe((res) => {
-      const filteredServices = res.results.filter((service) =>
-        service.uid.includes('blocto')
-      );
-      setServices(filteredServices);
-    });
+    if (process.env.REACT_APP_FLOW_ENV !== 'emulator') {
+      fcl.discovery.authn.subscribe((res) => {
+        const filteredServices = res.results.filter((service) =>
+          service.uid.includes('blocto')
+        );
+        setServices(filteredServices);
+      });
+    } else {
+      // hard code service for local dev
+      setServices([
+        {
+          f_type: 'Service',
+          f_vsn: '1.0.0',
+          type: 'authn',
+          method: 'IFRAME/RPC',
+          uid: 'blocto#authn',
+          provider: {
+            name: 'Blocto',
+            icon: '/images/blocto.png',
+          },
+        },
+      ]);
+    }
   }, []);
 
   const setWebContextConfig = useCallback((config) => {

--- a/frontend/packages/client/src/networks.js
+++ b/frontend/packages/client/src/networks.js
@@ -4,7 +4,7 @@ const networksConfig = {
     walletDiscovery:
       process.env.REACT_APP_EMULATOR_WALLET_DISCOVERY ||
       'http://localhost:8701/fcl/authn',
-    walletDiscoveryApi: 'https://fcl-discovery.onflow.org/api/testnet/authn',
+    walletDiscoveryApi: null,
     walletDiscoveryInclude: [],
     strategiesConfig: {
       'one-address-one-vote': {


### PR DESCRIPTION
On local dev, when using new modal  to connect to dev wallet frontend takes staging configuration for `walletDiscoveryApi` using the call `fcl.discovery.authn.subscribe` then it tries to connect to testnet. 
This PR removes the parameter `{ service }` from the call `injectedProvider.authenticate` to connect by default to local emulator instead of testnet. 
