### PR TITLE
fix strategy editor modal mobile scroll

### DIFF
--- a/frontend/packages/client/src/components/Community/StrategyEditorModal/index.js
+++ b/frontend/packages/client/src/components/Community/StrategyEditorModal/index.js
@@ -112,7 +112,7 @@ export default function StrategyEditorModal({
 
   return (
     <div
-      className="modal-card has-background-white m-0 p-5 p-1-mobile"
+      className="modal-card has-background-white m-0 p-5 p-1-mobile full-height"
       style={{ minHeight: '467px' }}
     >
       <header


### PR DESCRIPTION
this container wasn't being constrained to its parent height (which is the white modal card that has a max height of 100vh - 160px) so scrolling wasn't reaching the bottom on mobile the way it should