### PR TITLE
fix strategy update on community creation

### DIFF
--- a/frontend/packages/client/src/components/Community/StrategySelectorForm.js
+++ b/frontend/packages/client/src/components/Community/StrategySelectorForm.js
@@ -14,6 +14,7 @@ export default function StrategySelectorForm({
   callToAction = () => {},
   // callback to return strategies selected
   onStrategySelection,
+  enableDelUniqueItem,
 } = {}) {
   // holds array of objects with strategy information
   const [strategies, setStrategies] = useState(existingStrategies);
@@ -58,8 +59,8 @@ export default function StrategySelectorForm({
     setStrategies((state) => state.filter((_, idx) => idx !== index));
   };
 
-  // hide delete when there's only one strategy
-  const enableDelete = strategies.length > 1;
+  // hide delete when there's only one strategy unless passed by prop
+  const enableDelete = enableDelUniqueItem ?? strategies.length > 1;
 
   const callToActionComponent = callToAction(strategies);
 

--- a/frontend/packages/client/src/components/CommunityCreate/StepFour.js
+++ b/frontend/packages/client/src/components/CommunityCreate/StepFour.js
@@ -27,7 +27,7 @@ export default function StepFour({
     <StrategySelectorForm
       existingStrategies={strategies}
       onStrategySelection={onStrategySelection}
-      enableDelUniqueItem={true}
+      enableDelUniqueItem
       callToAction={() => {
         return (
           <ActionButton

--- a/frontend/packages/client/src/components/CommunityCreate/StepFour.js
+++ b/frontend/packages/client/src/components/CommunityCreate/StepFour.js
@@ -27,6 +27,7 @@ export default function StepFour({
     <StrategySelectorForm
       existingStrategies={strategies}
       onStrategySelection={onStrategySelection}
+      enableDelUniqueItem={true}
       callToAction={() => {
         return (
           <ActionButton

--- a/frontend/packages/client/src/pages/CommunityEditor.js
+++ b/frontend/packages/client/src/pages/CommunityEditor.js
@@ -154,8 +154,8 @@ export default function CommunityEditorPage() {
   // initial loading
   if (loading && !community) {
     return (
-      <section className="section">
-        <div className="container is-flex full-height">
+      <section className="section full-height">
+        <div className="container is-flex full-height is-justify-content-center">
           <Loader fullHeight />
         </div>
       </section>


### PR DESCRIPTION
- Fix loader position on edit community
- Allow to delete strategy on community creation when there is only one strategy. In case the information entered for the strategy is not valid, user needs to be able to delete the existing one to be able to add it again to fix the strategy data entered.