### PR TITLE
CAS-358: Fix leaderboard showing all accounts as connected account

### DIFF
--- a/frontend/packages/client/src/components/LeaderBoard.js
+++ b/frontend/packages/client/src/components/LeaderBoard.js
@@ -47,13 +47,14 @@ const LeaderBoard = ({
           {!isLoading &&
             data?.users.map((datum, index) => {
               const userIndex = index + 1;
+              const isCurrentUser = datum.addr === user?.addr;
               const indexClasses = classnames({
                 'index-cell': index === 0 || index === 4,
                 'rounded-sm-tl': index === 0,
                 'rounded-sm-bl': index === 4,
-                'has-background-white-ter': !currentUserInLeaderboard,
-                'has-background-black-bis': currentUserInLeaderboard,
-                'has-text-white': currentUserInLeaderboard,
+                'has-background-white-ter': !isCurrentUser,
+                'has-background-black-bis': isCurrentUser,
+                'has-text-white': isCurrentUser,
               });
 
               return (


### PR DESCRIPTION
**Ticket:** [CAS-358](https://linear.app/dappercollectives/issue/CAS-358/all-voters-displayed-as-current-user-on-leaderboard)

**Description:**

- UI Logic was incorrectly showing all users as current user. Updated to only highlight the current user if they are on the leaderboard.

![Screen Shot 2022-07-26 at 11 55 43 AM](https://user-images.githubusercontent.com/22734700/181089389-d5b9bb45-0020-471e-90e9-d231cec3f507.png)
