### PR TITLE
Update eslint rules

### DIFF
--- a/frontend/packages/client/.eslintignore
+++ b/frontend/packages/client/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/frontend/packages/client/.eslintignore
+++ b/frontend/packages/client/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+build

--- a/frontend/packages/client/.prettierrc
+++ b/frontend/packages/client/.prettierrc
@@ -5,5 +5,17 @@
   "tabWidth": 2,
   "tabs": false,
   "semi": true,
-  "bracketSpacing": true
+  "bracketSpacing": true,
+  "importOrder": [
+    "react",
+    "contexts",
+    "components",
+    "hooks",
+    "const",
+    "utils",
+    "<THIRD_PARTY_MODULES>",
+    "^[./]"
+  ],
+  "importOrderSeparation": false,
+  "importOrderSortSpecifiers": true
 }

--- a/frontend/packages/client/package.json
+++ b/frontend/packages/client/package.json
@@ -6,6 +6,7 @@
     "@creativebulma/bulma-tooltip": "^1.2.0",
     "@onflow/fcl": "^1.2.0",
     "@onflow/six-transfer-tokens": "0.0.8",
+    "@trivago/prettier-plugin-sort-imports": "^3.3.0",
     "bulma": "0.9.3",
     "bulma-popover": "^1.1.1",
     "classnames": "^2.2.6",
@@ -65,34 +66,7 @@
         }
       ],
       "import/order": [
-        2,
-        {
-          "newlines-between": "never",
-          "groups": [
-            "builtin",
-            "external",
-            "internal",
-            "parent",
-            "sibling",
-            "index",
-            "unknown",
-            "object"
-          ],
-          "alphabetize": {
-            "order": "asc",
-            "caseInsensitive": true
-          },
-          "pathGroups": [
-            {
-              "pattern": "react*",
-              "group": "external",
-              "position": "before"
-            }
-          ],
-          "pathGroupsExcludedImportTypes": [
-            "react"
-          ]
-        }
+        0
       ],
       "react/no-multi-comp": [
         2,

--- a/frontend/packages/client/package.json
+++ b/frontend/packages/client/package.json
@@ -93,6 +93,12 @@
             "react"
           ]
         }
+      ],
+      "react/no-multi-comp": [
+        2,
+        {
+          "ignoreStateless": true
+        }
       ]
     }
   },

--- a/frontend/packages/client/package.json
+++ b/frontend/packages/client/package.json
@@ -63,6 +63,36 @@
         {
           "usePrettierrc": true
         }
+      ],
+      "import/order": [
+        2,
+        {
+          "newlines-between": "never",
+          "groups": [
+            "builtin",
+            "external",
+            "internal",
+            "parent",
+            "sibling",
+            "index",
+            "unknown",
+            "object"
+          ],
+          "alphabetize": {
+            "order": "asc",
+            "caseInsensitive": true
+          },
+          "pathGroups": [
+            {
+              "pattern": "react*",
+              "group": "external",
+              "position": "before"
+            }
+          ],
+          "pathGroupsExcludedImportTypes": [
+            "react"
+          ]
+        }
       ]
     }
   },

--- a/frontend/packages/client/src/App.js
+++ b/frontend/packages/client/src/App.js
@@ -1,14 +1,14 @@
+import React from 'react';
 import 'react-datepicker/dist/react-datepicker.css';
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
-import './App.sass';
-import React from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { ReactQueryDevtools } from 'react-query/devtools';
 import { HashRouter as Router } from 'react-router-dom';
-import { ErrorHandler } from 'components';
 import NotificationModalProvider from 'contexts/NotificationModal';
 import { Web3Provider } from 'contexts/Web3';
-import { ReactQueryDevtools } from 'react-query/devtools';
+import { ErrorHandler } from 'components';
+import './App.sass';
 import AppPages from './pages';
 import Error from './pages/Error';
 

--- a/frontend/packages/client/src/App.js
+++ b/frontend/packages/client/src/App.js
@@ -2,15 +2,15 @@ import 'react-datepicker/dist/react-datepicker.css';
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 import './App.sass';
 import React from 'react';
-import { HashRouter as Router } from 'react-router-dom';
-import { Web3Provider } from './contexts/Web3';
-import Error from './pages/Error';
-import { ErrorHandler } from './components';
-import NotificationModalProvider from './contexts/NotificationModal';
 import { ErrorBoundary } from 'react-error-boundary';
-import AppPages from './pages';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { HashRouter as Router } from 'react-router-dom';
+import { ErrorHandler } from 'components';
+import NotificationModalProvider from 'contexts/NotificationModal';
+import { Web3Provider } from 'contexts/Web3';
 import { ReactQueryDevtools } from 'react-query/devtools';
+import AppPages from './pages';
+import Error from './pages/Error';
 
 const isLocalDevMode = process.env.NODE_ENV === 'development';
 // create react-query client

--- a/frontend/packages/client/src/api/leaderboard.js
+++ b/frontend/packages/client/src/api/leaderboard.js
@@ -1,5 +1,5 @@
-import { checkResponse } from 'utils';
 import { COMMUNITIES_URL } from './constants';
+import { checkResponse } from 'utils';
 
 const DEFAULT_PAGE_SIZE = 10;
 const getLeaderBoardUrl = (communityId, addr, pageSize) =>

--- a/frontend/packages/client/src/api/leaderboard.js
+++ b/frontend/packages/client/src/api/leaderboard.js
@@ -1,4 +1,4 @@
-import { checkResponse } from '../utils';
+import { checkResponse } from 'utils';
 import { COMMUNITIES_URL } from './constants';
 
 const DEFAULT_PAGE_SIZE = 10;

--- a/frontend/packages/client/src/components/ActionButton.js
+++ b/frontend/packages/client/src/components/ActionButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import classnames from 'classnames';
 import Loader from 'components/Loader';
+import classnames from 'classnames';
 
 export default function ActionButton({
   enabled = true,

--- a/frontend/packages/client/src/components/ActionButton.js
+++ b/frontend/packages/client/src/components/ActionButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import Loader from 'components/Loader';
 import classnames from 'classnames';
+import Loader from 'components/Loader';
 
 export default function ActionButton({
   enabled = true,

--- a/frontend/packages/client/src/components/AddButton.js
+++ b/frontend/packages/client/src/components/AddButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import classnames from 'classnames';
 import { Plus } from 'components/Svg';
+import classnames from 'classnames';
 
 export default function AddButton({
   onAdd = () => {},

--- a/frontend/packages/client/src/components/Community/CommunitiesPresenter.js
+++ b/frontend/packages/client/src/components/Community/CommunitiesPresenter.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import CommunityCard from './CommunityCard';
+
 /**
  * CommunitiesPresenter will group communities on a row bases,
  * will use elementsPerRow to determine how many communities to render per row

--- a/frontend/packages/client/src/components/Community/CommunitiesPresenter.js
+++ b/frontend/packages/client/src/components/Community/CommunitiesPresenter.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import CommunityCard from './CommunityCard';
 import classnames from 'classnames';
+import CommunityCard from './CommunityCard';
 /**
  * CommunitiesPresenter will group communities on a row bases,
  * will use elementsPerRow to determine how many communities to render per row

--- a/frontend/packages/client/src/components/Community/CommunityCard.js
+++ b/frontend/packages/client/src/components/Community/CommunityCard.js
@@ -3,6 +3,7 @@ import Blockies from 'react-blockies';
 import { Link } from 'react-router-dom';
 import { useMediaQuery } from 'hooks';
 import JoinCommunityButton from './JoinCommunityButton';
+
 /**
  * CommunityCard will group communities on a row bases,
  * will use elementsPerRow to determine how many communities to render per row

--- a/frontend/packages/client/src/components/Community/CommunityCard.js
+++ b/frontend/packages/client/src/components/Community/CommunityCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import JoinCommunityButton from './JoinCommunityButton';
 import Blockies from 'react-blockies';
+import { Link } from 'react-router-dom';
 import { useMediaQuery } from 'hooks';
+import JoinCommunityButton from './JoinCommunityButton';
 /**
  * CommunityCard will group communities on a row bases,
  * will use elementsPerRow to determine how many communities to render per row

--- a/frontend/packages/client/src/components/Community/CommunityEditorDetails.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorDetails.js
@@ -1,14 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { WrapperResponsive, Loader, AddButton, FadeIn } from 'components';
 import { Bin, ValidCheckMark, InvalidCheckMark } from 'components/Svg';
-import { WrapperResponsive, Loader, AddButton } from 'components';
-import { useCommunityUsers } from 'hooks';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { useWebContext } from 'contexts/Web3';
+import { useCommunityUsers } from 'hooks';
 import { getCompositeSigs } from 'utils';
 import useFlowAddrValidator, {
   validateAddrInList,
 } from './hooks/useFlowAddrValidator';
-import FadeIn from 'components/FadeIn';
 
 export const CommunityUsersForm = ({
   title,
@@ -328,8 +327,8 @@ export default function CommunityEditorDetails({ communityId } = {}) {
   return (
     <>
       <CommunityMembersEditor
-        description="Admins can edit community settings and moderate proposals. 
-          We recommend at least two admin for each community, but it is not a requirement. 
+        description="Admins can edit community settings and moderate proposals.
+          We recommend at least two admin for each community, but it is not a requirement.
           Please add one address per line."
         type="admin"
         communityId={communityId}

--- a/frontend/packages/client/src/components/Community/CommunityEditorDetails.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorDetails.js
@@ -1,13 +1,13 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { WrapperResponsive, Loader, AddButton, FadeIn } from 'components';
-import { Bin, ValidCheckMark, InvalidCheckMark } from 'components/Svg';
+import React, { useEffect, useRef, useState } from 'react';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { useWebContext } from 'contexts/Web3';
-import { useCommunityUsers } from 'hooks';
-import { getCompositeSigs } from 'utils';
+import { AddButton, FadeIn, Loader, WrapperResponsive } from 'components';
+import { Bin, InvalidCheckMark, ValidCheckMark } from 'components/Svg';
 import useFlowAddrValidator, {
   validateAddrInList,
 } from './hooks/useFlowAddrValidator';
+import { useCommunityUsers } from 'hooks';
+import { getCompositeSigs } from 'utils';
 
 export const CommunityUsersForm = ({
   title,

--- a/frontend/packages/client/src/components/Community/CommunityEditorLinks.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorLinks.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { WrapperResponsive, Loader } from 'components';
-import { Website, Instagram, Twitter, Discord, Github } from 'components/Svg';
+import { Loader, WrapperResponsive } from 'components';
+import { Discord, Github, Instagram, Twitter, Website } from 'components/Svg';
 import useLinkValidator from './hooks/useLinkValidator';
 
 const FormFieldsConfig = [

--- a/frontend/packages/client/src/components/Community/CommunityEditorLinks.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorLinks.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { Website, Instagram, Twitter, Discord, Github } from 'components/Svg';
 import { WrapperResponsive, Loader } from 'components';
+import { Website, Instagram, Twitter, Discord, Github } from 'components/Svg';
 import useLinkValidator from './hooks/useLinkValidator';
 
 const FormFieldsConfig = [

--- a/frontend/packages/client/src/components/Community/CommunityEditorProfile.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorProfile.js
@@ -1,16 +1,16 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import classnames from 'classnames';
 import { useDropzone } from 'react-dropzone';
-import { Upload } from 'components/Svg';
+import classnames from 'classnames';
 import { WrapperResponsive, Loader } from 'components';
-import { getReducedImg, validateLength } from 'utils';
-import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { Upload } from 'components/Svg';
 import {
   MAX_AVATAR_FILE_SIZE,
   MAX_FILE_SIZE,
   COMMUNITY_DESCRIPTION_MAX_LENGTH,
   COMMUNITY_NAME_MAX_LENGTH,
 } from 'const';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { getReducedImg, validateLength } from 'utils';
 
 function CommunityEditorProfile({
   name,

--- a/frontend/packages/client/src/components/Community/CommunityEditorProfile.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorProfile.js
@@ -1,16 +1,16 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
-import classnames from 'classnames';
-import { WrapperResponsive, Loader } from 'components';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { Loader, WrapperResponsive } from 'components';
 import { Upload } from 'components/Svg';
 import {
-  MAX_AVATAR_FILE_SIZE,
-  MAX_FILE_SIZE,
   COMMUNITY_DESCRIPTION_MAX_LENGTH,
   COMMUNITY_NAME_MAX_LENGTH,
+  MAX_AVATAR_FILE_SIZE,
+  MAX_FILE_SIZE,
 } from 'const';
-import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { getReducedImg, validateLength } from 'utils';
+import classnames from 'classnames';
 
 function CommunityEditorProfile({
   name,

--- a/frontend/packages/client/src/components/Community/CommunityPropsAndVoting.js
+++ b/frontend/packages/client/src/components/Community/CommunityPropsAndVoting.js
@@ -1,11 +1,11 @@
 import React from 'react';
+import { useModalContext } from 'contexts/NotificationModal';
+import { useWebContext } from 'contexts/Web3';
 import { Error } from 'components';
 import ActionButton from 'components/ActionButton';
 import StrategySelectorForm from 'components/Community/StrategySelectorForm';
-import { useModalContext } from 'contexts/NotificationModal';
-import { useWebContext } from 'contexts/Web3';
-import isEqual from 'lodash/isEqual';
 import { kebabToString } from 'utils';
+import isEqual from 'lodash/isEqual';
 
 export default function CommunityProposalsAndVoting({
   communityVotingStrategies = [],

--- a/frontend/packages/client/src/components/Community/CommunityPropsAndVoting.js
+++ b/frontend/packages/client/src/components/Community/CommunityPropsAndVoting.js
@@ -1,10 +1,10 @@
 import React from 'react';
+import { Error } from 'components';
 import ActionButton from 'components/ActionButton';
 import StrategySelectorForm from 'components/Community/StrategySelectorForm';
-import isEqual from 'lodash/isEqual';
-import { useWebContext } from 'contexts/Web3';
 import { useModalContext } from 'contexts/NotificationModal';
-import { Error } from 'components';
+import { useWebContext } from 'contexts/Web3';
+import isEqual from 'lodash/isEqual';
 import { kebabToString } from 'utils';
 
 export default function CommunityProposalsAndVoting({

--- a/frontend/packages/client/src/components/Community/JoinCommunityButton.js
+++ b/frontend/packages/client/src/components/Community/JoinCommunityButton.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import classnames from 'classnames';
-import { WalletConnect, Error } from 'components';
 import { useModalContext } from 'contexts/NotificationModal';
 import { useWebContext } from 'contexts/Web3';
+import { Error, WalletConnect } from 'components';
 import { useJoinCommunity, useUserRoleOnCommunity } from 'hooks';
+import classnames from 'classnames';
 
 export default function JoinCommunityButton({
   communityId,

--- a/frontend/packages/client/src/components/Community/JoinCommunityButton.js
+++ b/frontend/packages/client/src/components/Community/JoinCommunityButton.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { useWebContext } from 'contexts/Web3';
-import { useModalContext } from 'contexts/NotificationModal';
-import { useJoinCommunity, useUserRoleOnCommunity } from 'hooks';
-import { WalletConnect, Error } from 'components';
 import classnames from 'classnames';
+import { WalletConnect, Error } from 'components';
+import { useModalContext } from 'contexts/NotificationModal';
+import { useWebContext } from 'contexts/Web3';
+import { useJoinCommunity, useUserRoleOnCommunity } from 'hooks';
 
 export default function JoinCommunityButton({
   communityId,

--- a/frontend/packages/client/src/components/Community/StrategyEditorModal/index.js
+++ b/frontend/packages/client/src/components/Community/StrategyEditorModal/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { ActionButton } from 'components';
-import networks from 'networks';
 import { isValidAddress } from 'utils';
+import networks from 'networks';
 import StrategyInformationForm from './StrategyInformationForm';
 import StrategySelector from './StrategySelector';
 

--- a/frontend/packages/client/src/components/Community/StrategyEditorModal/index.js
+++ b/frontend/packages/client/src/components/Community/StrategyEditorModal/index.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import networks from 'networks';
-import StrategySelector from './StrategySelector';
-import StrategyInformationForm from './StrategyInformationForm';
 import { ActionButton } from 'components';
+import networks from 'networks';
 import { isValidAddress } from 'utils';
+import StrategyInformationForm from './StrategyInformationForm';
+import StrategySelector from './StrategySelector';
 
 const networkConfig = networks[process.env.REACT_APP_FLOW_ENV];
 

--- a/frontend/packages/client/src/components/Community/StrategySelectorForm.js
+++ b/frontend/packages/client/src/components/Community/StrategySelectorForm.js
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
+import { useModalContext } from 'contexts/NotificationModal';
 import { AddButton } from 'components';
 import StrategySelectorInput from 'components/Community/StrategySelectorInput';
-import { useModalContext } from 'contexts/NotificationModal';
 import { useVotingStrategies } from 'hooks';
-import isEqual from 'lodash/isEqual';
 import { kebabToString } from 'utils';
+import isEqual from 'lodash/isEqual';
 import StrategyEditorModal from './StrategyEditorModal';
 
 export default function StrategySelectorForm({

--- a/frontend/packages/client/src/components/Community/StrategySelectorForm.js
+++ b/frontend/packages/client/src/components/Community/StrategySelectorForm.js
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import isEqual from 'lodash/isEqual';
 import { AddButton } from 'components';
-import { useModalContext } from 'contexts/NotificationModal';
-import StrategyEditorModal from './StrategyEditorModal';
 import StrategySelectorInput from 'components/Community/StrategySelectorInput';
+import { useModalContext } from 'contexts/NotificationModal';
 import { useVotingStrategies } from 'hooks';
+import isEqual from 'lodash/isEqual';
 import { kebabToString } from 'utils';
+import StrategyEditorModal from './StrategyEditorModal';
 
 export default function StrategySelectorForm({
   existingStrategies = [],

--- a/frontend/packages/client/src/components/Community/hooks/useFlowAddrValidator.js
+++ b/frontend/packages/client/src/components/Community/hooks/useFlowAddrValidator.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { isValidAddress } from 'utils';
 
 const uniqueElements = (adminList) => {

--- a/frontend/packages/client/src/components/Community/hooks/useLinkValidator.js
+++ b/frontend/packages/client/src/components/Community/hooks/useLinkValidator.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import isEqual from 'lodash/isEqual';
-import pickBy from 'lodash/pickBy';
 import pick from 'lodash/pick';
+import pickBy from 'lodash/pickBy';
 
 export const urlPatternValidation = (url) => {
   const regex = new RegExp(

--- a/frontend/packages/client/src/components/Community/hooks/useLinkValidator.js
+++ b/frontend/packages/client/src/components/Community/hooks/useLinkValidator.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';

--- a/frontend/packages/client/src/components/CommunityCreate/StartSteps.js
+++ b/frontend/packages/client/src/components/CommunityCreate/StartSteps.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import classnames from 'classnames';
 import { useMediaQuery } from 'hooks';
+import classnames from 'classnames';
 
 export default function StartSteps({ dismissPreStep }) {
   const { notMobile } = useMediaQuery();

--- a/frontend/packages/client/src/components/CommunityCreate/StartSteps.js
+++ b/frontend/packages/client/src/components/CommunityCreate/StartSteps.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { useMediaQuery } from 'hooks';
 import classnames from 'classnames';
+import { useMediaQuery } from 'hooks';
 
 export default function StartSteps({ dismissPreStep }) {
   const { notMobile } = useMediaQuery();

--- a/frontend/packages/client/src/components/CommunityCreate/StepFour.js
+++ b/frontend/packages/client/src/components/CommunityCreate/StepFour.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
-import StrategySelectorForm from 'components/Community/StrategySelectorForm';
 import ActionButton from 'components/ActionButton';
+import StrategySelectorForm from 'components/Community/StrategySelectorForm';
 
 export default function StepFour({
   stepData,

--- a/frontend/packages/client/src/components/CommunityCreate/StepOne.js
+++ b/frontend/packages/client/src/components/CommunityCreate/StepOne.js
@@ -1,22 +1,22 @@
 import React, { useEffect, useCallback } from 'react';
-import classnames from 'classnames';
 import { useDropzone } from 'react-dropzone';
-import { Upload } from 'components/Svg';
+import classnames from 'classnames';
 import { WrapperResponsive, Dropdown } from 'components';
 import { CommunityLinksForm } from 'components/Community/CommunityEditorLinks';
-import useLinkValidator, {
-  urlPatternValidation,
-} from '../Community/hooks/useLinkValidator';
-import { getReducedImg, validateLength } from 'utils';
-import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { Upload } from 'components/Svg';
 import {
   MAX_AVATAR_FILE_SIZE,
   MAX_FILE_SIZE,
   COMMUNITY_NAME_MAX_LENGTH,
   COMMUNITY_DESCRIPTION_MAX_LENGTH,
 } from 'const';
-import pick from 'lodash/pick';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { useCommunityCategory } from 'hooks';
+import pick from 'lodash/pick';
+import { getReducedImg, validateLength } from 'utils';
+import useLinkValidator, {
+  urlPatternValidation,
+} from '../Community/hooks/useLinkValidator';
 
 const linksFields = [
   'websiteUrl',

--- a/frontend/packages/client/src/components/CommunityCreate/StepOne.js
+++ b/frontend/packages/client/src/components/CommunityCreate/StepOne.js
@@ -1,22 +1,22 @@
-import React, { useEffect, useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useDropzone } from 'react-dropzone';
-import classnames from 'classnames';
-import { WrapperResponsive, Dropdown } from 'components';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { Dropdown, WrapperResponsive } from 'components';
 import { CommunityLinksForm } from 'components/Community/CommunityEditorLinks';
 import { Upload } from 'components/Svg';
-import {
-  MAX_AVATAR_FILE_SIZE,
-  MAX_FILE_SIZE,
-  COMMUNITY_NAME_MAX_LENGTH,
-  COMMUNITY_DESCRIPTION_MAX_LENGTH,
-} from 'const';
-import { useErrorHandlerContext } from 'contexts/ErrorHandler';
-import { useCommunityCategory } from 'hooks';
-import pick from 'lodash/pick';
-import { getReducedImg, validateLength } from 'utils';
 import useLinkValidator, {
   urlPatternValidation,
 } from '../Community/hooks/useLinkValidator';
+import { useCommunityCategory } from 'hooks';
+import {
+  COMMUNITY_DESCRIPTION_MAX_LENGTH,
+  COMMUNITY_NAME_MAX_LENGTH,
+  MAX_AVATAR_FILE_SIZE,
+  MAX_FILE_SIZE,
+} from 'const';
+import { getReducedImg, validateLength } from 'utils';
+import classnames from 'classnames';
+import pick from 'lodash/pick';
 
 const linksFields = [
   'websiteUrl',

--- a/frontend/packages/client/src/components/CommunityCreate/StepTwo.js
+++ b/frontend/packages/client/src/components/CommunityCreate/StepTwo.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import Popover from 'components/Popover';
-import { CommunityUsersForm } from '../Community/CommunityEditorDetails';
 import useFlowAddrValidator from '../Community/hooks/useFlowAddrValidator';
+import { CommunityUsersForm } from '../Community/CommunityEditorDetails';
 
 const isInitialList = (listAddr) => {
   return listAddr?.length === 1 && listAddr[0].addr === '';

--- a/frontend/packages/client/src/components/CommunityCreate/StepTwo.js
+++ b/frontend/packages/client/src/components/CommunityCreate/StepTwo.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
+import Popover from 'components/Popover';
 import { CommunityUsersForm } from '../Community/CommunityEditorDetails';
 import useFlowAddrValidator from '../Community/hooks/useFlowAddrValidator';
-import Popover from 'components/Popover';
 
 const isInitialList = (listAddr) => {
   return listAddr?.length === 1 && listAddr[0].addr === '';

--- a/frontend/packages/client/src/components/CommunityHeader.js
+++ b/frontend/packages/client/src/components/CommunityHeader.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import Blockies from 'react-blockies';
 import { JoinCommunityButton } from 'components';
 import { useMediaQuery } from 'hooks';
-import Blockies from 'react-blockies';
 
 export default function CommunityHeader({
   isLoading = false,

--- a/frontend/packages/client/src/components/CommunityLinks.js
+++ b/frontend/packages/client/src/components/CommunityLinks.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Twitter, Discord, Website, Instagram, Github } from './Svg';
 import { Title } from '.';
+import { Discord, Github, Instagram, Twitter, Website } from './Svg';
 
 export default function CommunityLinks({
   instagramUrl,

--- a/frontend/packages/client/src/components/CommunityMembersList.js
+++ b/frontend/packages/client/src/components/CommunityMembersList.js
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
 import { useWebContext } from 'contexts/Web3';
 import { useCommunityMembers } from 'hooks';
-import TableMembers from './TableMembers';
 import { debounce } from 'utils';
+import TableMembers from './TableMembers';
 import WrapperResponsive from './WrapperResponsive';
 
 export default function CommunityMembersList({ communityId } = {}) {

--- a/frontend/packages/client/src/components/CommunityProposals.js
+++ b/frontend/packages/client/src/components/CommunityProposals.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import CommunityProposalList from './CommunityProposalList';
-import { useCommunityProposalsWithVotes, useMediaQuery } from '../hooks';
 import { FilterValues } from '../const';
+import { useCommunityProposalsWithVotes, useMediaQuery } from '../hooks';
+import CommunityProposalList from './CommunityProposalList';
 import DropDown from './Dropdown';
 import WrapperResponsive from './WrapperResponsive';
 

--- a/frontend/packages/client/src/components/CommunityProposals.js
+++ b/frontend/packages/client/src/components/CommunityProposals.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { FilterValues } from '../const';
 import { useCommunityProposalsWithVotes, useMediaQuery } from '../hooks';
+import { FilterValues } from 'const';
 import CommunityProposalList from './CommunityProposalList';
 import DropDown from './Dropdown';
 import WrapperResponsive from './WrapperResponsive';

--- a/frontend/packages/client/src/components/CommunityPulse.js
+++ b/frontend/packages/client/src/components/CommunityPulse.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import WrapperResponsive from './WrapperResponsive';
 import Miquela from '../assets/miquela.png';
 import PeopleToast from '../assets/people-toast.png';
+import WrapperResponsive from './WrapperResponsive';
 
 export default function CommunityPulse() {
   return (

--- a/frontend/packages/client/src/components/Dropdown.js
+++ b/frontend/packages/client/src/components/Dropdown.js
@@ -1,4 +1,4 @@
-import React, { useState, forwardRef } from 'react';
+import React, { forwardRef, useState } from 'react';
 import classnames from 'classnames';
 import { CaretDown } from './Svg';
 

--- a/frontend/packages/client/src/components/Dropdown.js
+++ b/frontend/packages/client/src/components/Dropdown.js
@@ -1,6 +1,6 @@
 import React, { useState, forwardRef } from 'react';
-import { CaretDown } from './Svg';
 import classnames from 'classnames';
+import { CaretDown } from './Svg';
 
 const DropDown = forwardRef(
   (

--- a/frontend/packages/client/src/components/Dropdown.test.js
+++ b/frontend/packages/client/src/components/Dropdown.test.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-
-import '@testing-library/jest-dom';
 import renderer from 'react-test-renderer';
-import Dropdown from './Dropdown';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
+import Dropdown from './Dropdown';
 
 describe('Dropdown UI Component', () => {
   it(`renders correctly`, () => {

--- a/frontend/packages/client/src/components/Dropdown.test.js
+++ b/frontend/packages/client/src/components/Dropdown.test.js
@@ -1,6 +1,6 @@
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import Dropdown from './Dropdown';

--- a/frontend/packages/client/src/components/Header.js
+++ b/frontend/packages/client/src/components/Header.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { NavLink, withRouter } from 'react-router-dom';
 import Sidenavbar from './SideNavbar';
-import { Logo, LinkOut } from './Svg';
+import { LinkOut, Logo } from './Svg';
 import WalletConnect from './WalletConnect';
 
 function Header(props) {

--- a/frontend/packages/client/src/components/LeaderBoard.js
+++ b/frontend/packages/client/src/components/LeaderBoard.js
@@ -1,9 +1,9 @@
-import { Web3Consumer } from 'contexts/Web3';
 import React from 'react';
 import Blockies from 'react-blockies';
 import classnames from 'classnames';
-import { WrapperResponsive } from '../components';
-import { useLeaderBoard } from '../hooks';
+import { WrapperResponsive } from 'components';
+import { Web3Consumer } from 'contexts/Web3';
+import { useLeaderBoard } from 'hooks';
 
 const Row = ({ index, addr, score, classNameIndex }) => {
   const smallRowStyle = { width: '30%' };

--- a/frontend/packages/client/src/components/LeaderBoard.js
+++ b/frontend/packages/client/src/components/LeaderBoard.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import Blockies from 'react-blockies';
-import classnames from 'classnames';
-import { WrapperResponsive } from 'components';
 import { Web3Consumer } from 'contexts/Web3';
+import { WrapperResponsive } from 'components';
 import { useLeaderBoard } from 'hooks';
+import classnames from 'classnames';
 
 const Row = ({ index, addr, score, classNameIndex }) => {
   const smallRowStyle = { width: '30%' };

--- a/frontend/packages/client/src/components/Message.js
+++ b/frontend/packages/client/src/components/Message.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import WrapperResponsive from './WrapperResponsive';
 import Label from './Label';
+import WrapperResponsive from './WrapperResponsive';
 
 const Message = ({ messageText = '', labelText = null, icon = null } = {}) => {
   const labelComponent = labelText ? <Label labelText={labelText} /> : null;

--- a/frontend/packages/client/src/components/ModalAboutItem.js
+++ b/frontend/packages/client/src/components/ModalAboutItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Star } from '../components/Svg';
+import { Star } from 'components/Svg';
 
 export default function ModalAboutItem({
   closeModal = () => {},

--- a/frontend/packages/client/src/components/Popover.js
+++ b/frontend/packages/client/src/components/Popover.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { useMediaQuery } from 'hooks';
 import classnames from 'classnames';
+import { useMediaQuery } from 'hooks';
 
 const defaultButtonStyle = {
   border: 'none',

--- a/frontend/packages/client/src/components/Popover.js
+++ b/frontend/packages/client/src/components/Popover.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import classnames from 'classnames';
 import { useMediaQuery } from 'hooks';
+import classnames from 'classnames';
 
 const defaultButtonStyle = {
   border: 'none',

--- a/frontend/packages/client/src/components/Proposal/CancelProposalModalConfirmation.js
+++ b/frontend/packages/client/src/components/Proposal/CancelProposalModalConfirmation.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Loader } from 'components';
 
 const CancelProposalModalConfirmation = ({

--- a/frontend/packages/client/src/components/Proposal/ProposalStatus.js
+++ b/frontend/packages/client/src/components/Proposal/ProposalStatus.js
@@ -1,8 +1,8 @@
 import React from 'react';
+import { StatusLabel } from 'components';
+import { FilterValues } from 'const';
 import { parseDateFromServer } from 'utils';
 import { getStatus } from './getStatus';
-import { FilterValues } from 'const';
-import { StatusLabel } from 'components';
 
 const ProposalStatus = ({ proposal, className = '' }) => {
   const { diffFromNow: endDiff, diffDays } = parseDateFromServer(

--- a/frontend/packages/client/src/components/Proposal/VoteOptions.js
+++ b/frontend/packages/client/src/components/Proposal/VoteOptions.js
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { FilterValues } from 'const';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useVotesForAddress } from 'hooks';
-import { parseDateFromServer, getProposalType } from 'utils';
+import { FilterValues } from 'const';
+import { getProposalType, parseDateFromServer } from 'utils';
 import { WrapperResponsive as Wrapper } from '..';
 import { getStatus } from './getStatus';
 

--- a/frontend/packages/client/src/components/Proposal/VoteOptions.js
+++ b/frontend/packages/client/src/components/Proposal/VoteOptions.js
@@ -1,9 +1,9 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { WrapperResponsive as Wrapper } from '..';
-import { parseDateFromServer, getProposalType } from 'utils';
-import { useVotesForAddress } from 'hooks';
-import { getStatus } from './getStatus';
 import { FilterValues } from 'const';
+import { useVotesForAddress } from 'hooks';
+import { parseDateFromServer, getProposalType } from 'utils';
+import { WrapperResponsive as Wrapper } from '..';
+import { getStatus } from './getStatus';
 
 const TextBasedOptions = ({
   choices,

--- a/frontend/packages/client/src/components/ProposalCard/ProposalCardFooter.js
+++ b/frontend/packages/client/src/components/ProposalCard/ProposalCardFooter.js
@@ -1,10 +1,10 @@
 import React, { useMemo } from 'react';
-import millify from 'millify';
-import { Active, CheckCircle } from 'components/Svg';
-import { parseDateFromServer } from 'utils';
 import { StatusLabel, WrapperResponsive } from 'components';
-import { useVotingResults } from 'hooks';
+import { Active, CheckCircle } from 'components/Svg';
 import { FilterValues } from 'const';
+import { useVotingResults } from 'hooks';
+import millify from 'millify';
+import { parseDateFromServer } from 'utils';
 
 const IconAndText = ({ endTime, voted, status }) => {
   const { data: votingResults } = useVotingResults();

--- a/frontend/packages/client/src/components/ProposalCard/ProposalCardFooter.js
+++ b/frontend/packages/client/src/components/ProposalCard/ProposalCardFooter.js
@@ -1,10 +1,10 @@
 import React, { useMemo } from 'react';
 import { StatusLabel, WrapperResponsive } from 'components';
 import { Active, CheckCircle } from 'components/Svg';
-import { FilterValues } from 'const';
 import { useVotingResults } from 'hooks';
-import millify from 'millify';
+import { FilterValues } from 'const';
 import { parseDateFromServer } from 'utils';
+import millify from 'millify';
 
 const IconAndText = ({ endTime, voted, status }) => {
   const { data: votingResults } = useVotingResults();

--- a/frontend/packages/client/src/components/ProposalCard/ProposalCardHeader.js
+++ b/frontend/packages/client/src/components/ProposalCard/ProposalCardHeader.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Star } from 'components/Svg';
 import Blockies from 'react-blockies';
+import { Star } from 'components/Svg';
 
 const ProposalCardHeader = ({ creatorAddr, isAdminProposal }) => {
   return (

--- a/frontend/packages/client/src/components/ProposalCard/ProposalCardHeader.test.js
+++ b/frontend/packages/client/src/components/ProposalCard/ProposalCardHeader.test.js
@@ -1,6 +1,6 @@
+import { cleanup, render } from '@testing-library/react';
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { cleanup, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ProposalCardHeader from './ProposalCardHeader';
 

--- a/frontend/packages/client/src/components/ProposalCard/ProposalCardHeader.test.js
+++ b/frontend/packages/client/src/components/ProposalCard/ProposalCardHeader.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import renderer from 'react-test-renderer';
 import { cleanup, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import renderer from 'react-test-renderer';
 import ProposalCardHeader from './ProposalCardHeader';
 
 const date = new Date();

--- a/frontend/packages/client/src/components/ProposalCreate/StepOne/ImageChoiceUploader.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepOne/ImageChoiceUploader.js
@@ -1,9 +1,9 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Loader } from 'components';
-import { Upload, Bin } from 'components/Svg';
-import { MAX_FILE_SIZE } from 'const';
+import { Bin, Upload } from 'components/Svg';
 import { useFileUploader } from 'hooks';
+import { MAX_FILE_SIZE } from 'const';
 
 const IMAGE_STATUS = {
   notStarted: 'not-started',

--- a/frontend/packages/client/src/components/ProposalCreate/StepOne/ImageChoiceUploader.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepOne/ImageChoiceUploader.js
@@ -1,9 +1,9 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { useDropzone } from 'react-dropzone';
-import { useFileUploader } from 'hooks';
-import { Upload, Bin } from 'components/Svg';
 import { Loader } from 'components';
+import { Upload, Bin } from 'components/Svg';
 import { MAX_FILE_SIZE } from 'const';
+import { useFileUploader } from 'hooks';
 
 const IMAGE_STATUS = {
   notStarted: 'not-started',

--- a/frontend/packages/client/src/components/ProposalCreate/StepOne/ImageChoices.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepOne/ImageChoices.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
+import { getProposalType } from 'utils';
 import ImageChoiceUploader from './ImageChoiceUploader';
-import { getProposalType } from '../../../utils';
 
 const ImageChoices = ({ choices = [], onChoiceChange, initChoices } = {}) => {
   useEffect(() => {

--- a/frontend/packages/client/src/components/ProposalCreate/StepOne/TextBasedChoices.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepOne/TextBasedChoices.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
+import AddButton from 'components/AddButton';
 import { Bin } from 'components/Svg';
 import { getProposalType } from 'utils';
-import AddButton from 'components/AddButton';
 
 const TextBasedChoices = ({
   choices = [],

--- a/frontend/packages/client/src/components/ProposalCreate/StepOne/index.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepOne/index.js
@@ -6,6 +6,9 @@ import React, {
   useRef,
 } from 'react';
 import { Editor } from 'react-draft-wysiwyg';
+import { Dropdown, Error, UploadImageModal } from 'components';
+import { Image } from 'components/Svg';
+import { useModalContext } from 'contexts/NotificationModal';
 import {
   EditorState,
   AtomicBlockUtils,
@@ -14,14 +17,11 @@ import {
   DefaultDraftBlockRenderMap,
   SelectionState,
 } from 'draft-js';
-import { Map } from 'immutable';
 import { useQueryParams, useCommunityDetails } from 'hooks';
-import { useModalContext } from 'contexts/NotificationModal';
-import { Dropdown, Error, UploadImageModal } from 'components';
-import TextBasedChoices from './TextBasedChoices';
-import ImageChoices from './ImageChoices';
-import { Image } from 'components/Svg';
+import { Map } from 'immutable';
 import { kebabToString } from 'utils';
+import ImageChoices from './ImageChoices';
+import TextBasedChoices from './TextBasedChoices';
 
 const checkValidTitleLength = (text) => text?.length <= 128;
 

--- a/frontend/packages/client/src/components/ProposalCreate/StepOne/index.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepOne/index.js
@@ -1,25 +1,25 @@
 import React, {
-  useState,
-  useEffect,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import { Editor } from 'react-draft-wysiwyg';
+import { useModalContext } from 'contexts/NotificationModal';
 import { Dropdown, Error, UploadImageModal } from 'components';
 import { Image } from 'components/Svg';
-import { useModalContext } from 'contexts/NotificationModal';
+import { useCommunityDetails, useQueryParams } from 'hooks';
+import { kebabToString } from 'utils';
 import {
-  EditorState,
   AtomicBlockUtils,
-  Modifier,
   ContentState,
   DefaultDraftBlockRenderMap,
+  EditorState,
+  Modifier,
   SelectionState,
 } from 'draft-js';
-import { useQueryParams, useCommunityDetails } from 'hooks';
 import { Map } from 'immutable';
-import { kebabToString } from 'utils';
 import ImageChoices from './ImageChoices';
 import TextBasedChoices from './TextBasedChoices';
 

--- a/frontend/packages/client/src/components/ProposalCreate/StepThree.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepThree.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { parseDateToServer } from 'utils';
 import { customDraftToHTML } from 'utils';
 import { ProposalStatus, VoteOptions } from '../Proposal';

--- a/frontend/packages/client/src/components/ProposalCreate/StepThree.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepThree.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useCallback } from 'react';
-import { ProposalStatus, VoteOptions } from '../Proposal';
 import { parseDateToServer } from 'utils';
 import { customDraftToHTML } from 'utils';
+import { ProposalStatus, VoteOptions } from '../Proposal';
 
 const StepThree = ({ stepsData, setStepValid }) => {
   const setPreviewValid = useCallback(() => {

--- a/frontend/packages/client/src/components/ProposalInformation.js
+++ b/frontend/packages/client/src/components/ProposalInformation.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
 import Blockies from 'react-blockies';
+import { useVotingResults, useWindowDimensions } from 'hooks';
+import useMediaQuery, { mediaMatchers } from 'hooks/useMediaQuery';
+import { parseDateFromServer } from 'utils';
 import { LinkOut } from './Svg';
-import { parseDateFromServer } from '../utils';
-import { useVotingResults, useWindowDimensions } from '../hooks';
-import useMediaQuery, { mediaMatchers } from '../hooks/useMediaQuery';
 import Tooltip from './Tooltip';
 
 function truncate(str) {

--- a/frontend/packages/client/src/components/ProposalInformation.test.js
+++ b/frontend/packages/client/src/components/ProposalInformation.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import renderer from 'react-test-renderer';
 import { cleanup, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import renderer from 'react-test-renderer';
 import ProposalInformation from './ProposalInformation';
 
 let documentMock;

--- a/frontend/packages/client/src/components/ProposalInformation.test.js
+++ b/frontend/packages/client/src/components/ProposalInformation.test.js
@@ -1,6 +1,6 @@
+import { cleanup, render } from '@testing-library/react';
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { cleanup, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ProposalInformation from './ProposalInformation';
 

--- a/frontend/packages/client/src/components/SideNavbar.js
+++ b/frontend/packages/client/src/components/SideNavbar.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Logo, LinkOut } from './Svg';
 import { NavLink } from 'react-router-dom';
+import { Logo, LinkOut } from './Svg';
 
 const Sidenavbar = ({ showSidenav, closeSidenav }) => {
   return (

--- a/frontend/packages/client/src/components/SideNavbar.js
+++ b/frontend/packages/client/src/components/SideNavbar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { Logo, LinkOut } from './Svg';
+import { LinkOut, Logo } from './Svg';
 
 const Sidenavbar = ({ showSidenav, closeSidenav }) => {
   return (

--- a/frontend/packages/client/src/components/StepByStep/index.js
+++ b/frontend/packages/client/src/components/StepByStep/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useBeforeUnload } from 'hooks';
 import Loader from '../Loader';
 import { ArrowLeft, CheckMark } from '../Svg';

--- a/frontend/packages/client/src/components/StepByStep/index.js
+++ b/frontend/packages/client/src/components/StepByStep/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
-import { ArrowLeft, CheckMark } from '../Svg';
+import { useBeforeUnload } from 'hooks';
 import Loader from '../Loader';
-import { useBeforeUnload } from '../../hooks';
+import { ArrowLeft, CheckMark } from '../Svg';
 
 function StepByStep({
   finalLabel,
@@ -83,7 +83,7 @@ function StepByStep({
       return (
         <div className={`is-flex ${stepClasses.join(' ')}`} key={stepIdx}>
           <div
-            className="rounded-full has-text-black has-background-orange is-flex 
+            className="rounded-full has-text-black has-background-orange is-flex
               is-align-items-center is-justify-content-center"
             style={{
               width: 30,

--- a/frontend/packages/client/src/components/TableMembers.js
+++ b/frontend/packages/client/src/components/TableMembers.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import Loader from './Loader';
 import Blockies from 'react-blockies';
-import FadeIn from '../components/FadeIn';
 import classnames from 'classnames';
+import FadeIn from 'components/FadeIn';
+import Loader from './Loader';
 // import WrapperResponsive from "./WrapperResponsive";
 
 const Row = ({

--- a/frontend/packages/client/src/components/TableMembers.js
+++ b/frontend/packages/client/src/components/TableMembers.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import Blockies from 'react-blockies';
-import classnames from 'classnames';
 import FadeIn from 'components/FadeIn';
+import classnames from 'classnames';
 import Loader from './Loader';
+
 // import WrapperResponsive from "./WrapperResponsive";
 
 const Row = ({

--- a/frontend/packages/client/src/components/Transactions.js
+++ b/frontend/packages/client/src/components/Transactions.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Web3Consumer } from '../contexts/Web3';
 
 function Transaction({ web3 }) {

--- a/frontend/packages/client/src/components/UploadImageModal.js
+++ b/frontend/packages/client/src/components/UploadImageModal.js
@@ -1,9 +1,9 @@
 import React, { useCallback, useState, useEffect, useMemo } from 'react';
 import { useDropzone } from 'react-dropzone';
-import { useFileUploader, useMediaQuery } from 'hooks';
-import { Upload, Bin } from 'components/Svg';
 import { Loader } from 'components';
+import { Upload, Bin } from 'components/Svg';
 import { MAX_PROPOSAL_IMAGE_FILE_SIZE } from 'const';
+import { useFileUploader, useMediaQuery } from 'hooks';
 
 const MAX_IMAGE_FILES = 1;
 

--- a/frontend/packages/client/src/components/UploadImageModal.js
+++ b/frontend/packages/client/src/components/UploadImageModal.js
@@ -1,9 +1,9 @@
-import React, { useCallback, useState, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Loader } from 'components';
-import { Upload, Bin } from 'components/Svg';
-import { MAX_PROPOSAL_IMAGE_FILE_SIZE } from 'const';
+import { Bin, Upload } from 'components/Svg';
 import { useFileUploader, useMediaQuery } from 'hooks';
+import { MAX_PROPOSAL_IMAGE_FILE_SIZE } from 'const';
 
 const MAX_IMAGE_FILES = 1;
 

--- a/frontend/packages/client/src/components/VotesList.js
+++ b/frontend/packages/client/src/components/VotesList.js
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
-import millify from 'millify';
-import { AngleDown, AngleUp } from './Svg';
 import Blockies from 'react-blockies';
 import { useProposalVotes } from 'hooks';
+import millify from 'millify';
+import { AngleDown, AngleUp } from './Svg';
 
 const Core = () => (
   <div className="subtitle small-text p-2 rounded-sm has-background-white-ter has-text-black is-family-monospace">

--- a/frontend/packages/client/src/components/WalletConnectModal.js
+++ b/frontend/packages/client/src/components/WalletConnectModal.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import classnames from 'classnames';
 import { IS_LOCAL_DEV } from 'const';
+import classnames from 'classnames';
 import sortBy from 'lodash/sortBy';
 import { ArrowRight, Close } from './Svg';
 

--- a/frontend/packages/client/src/components/WalletConnectModal.js
+++ b/frontend/packages/client/src/components/WalletConnectModal.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import classnames from 'classnames';
+import { IS_LOCAL_DEV } from 'const';
 import sortBy from 'lodash/sortBy';
 import { ArrowRight, Close } from './Svg';
-import { IS_LOCAL_DEV } from 'const';
 
 const walletIcon = {
   Blocto: 'https://fcl-discovery.onflow.org/images/blocto.png',

--- a/frontend/packages/client/src/components/WrapperResponsive.js
+++ b/frontend/packages/client/src/components/WrapperResponsive.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { useMediaQuery } from '../hooks';
+import { useMediaQuery } from 'hooks';
 
 export default function WrapperResponsive({
   as: Tag = 'div',

--- a/frontend/packages/client/src/contexts/ErrorHandler.js
+++ b/frontend/packages/client/src/contexts/ErrorHandler.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState, useMemo } from 'react';
+import { Error } from 'components';
 import { useModalContext } from './NotificationModal';
-import { Error } from '../components';
 
 const ErrorHandlerContext = React.createContext({});
 

--- a/frontend/packages/client/src/contexts/ErrorHandler.js
+++ b/frontend/packages/client/src/contexts/ErrorHandler.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Error } from 'components';
 import { useModalContext } from './NotificationModal';
 

--- a/frontend/packages/client/src/contexts/Web3.js
+++ b/frontend/packages/client/src/contexts/Web3.js
@@ -1,8 +1,8 @@
-import React, { useEffect, useState, useCallback } from 'react';
-import * as fcl from '@onflow/fcl';
+import React, { useCallback, useEffect, useState } from 'react';
 import { WalletConnectModal } from 'components';
-import { IS_LOCAL_DEV } from 'const';
 import { useFclUser } from 'hooks';
+import { IS_LOCAL_DEV } from 'const';
+import * as fcl from '@onflow/fcl';
 import networks from 'networks';
 
 // create our app context

--- a/frontend/packages/client/src/contexts/Web3.js
+++ b/frontend/packages/client/src/contexts/Web3.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import * as fcl from '@onflow/fcl';
-import networks from 'networks';
-import { useFclUser } from 'hooks';
 import { WalletConnectModal } from 'components';
 import { IS_LOCAL_DEV } from 'const';
+import { useFclUser } from 'hooks';
+import networks from 'networks';
 
 // create our app context
 export const Web3Context = React.createContext({});

--- a/frontend/packages/client/src/hooks/useAllProposalVotes.js
+++ b/frontend/packages/client/src/hooks/useAllProposalVotes.js
@@ -1,11 +1,11 @@
 import { useReducer, useCallback } from 'react';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { checkResponse } from 'utils';
 import {
   paginationReducer,
   PAGINATION_INITIAL_STATE,
   INITIAL_STATE,
 } from '../reducers';
-import { checkResponse } from '../utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 
 /**
  * Hook to return proposal votes for a proposal. Results are paginated

--- a/frontend/packages/client/src/hooks/useAllProposalVotes.js
+++ b/frontend/packages/client/src/hooks/useAllProposalVotes.js
@@ -1,10 +1,10 @@
-import { useReducer, useCallback } from 'react';
+import { useCallback, useReducer } from 'react';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { checkResponse } from 'utils';
 import {
-  paginationReducer,
-  PAGINATION_INITIAL_STATE,
   INITIAL_STATE,
+  PAGINATION_INITIAL_STATE,
+  paginationReducer,
 } from '../reducers';
 
 /**

--- a/frontend/packages/client/src/hooks/useAllowlist.js
+++ b/frontend/packages/client/src/hooks/useAllowlist.js
@@ -1,7 +1,7 @@
 import { useReducer, useEffect, useCallback } from 'react';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { checkResponse } from 'utils';
 import { defaultReducer, INITIAL_STATE } from '../reducers';
-import { checkResponse } from '../utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 
 export default function useAllowlist() {
   const [state, dispatch] = useReducer(defaultReducer, INITIAL_STATE);

--- a/frontend/packages/client/src/hooks/useAllowlist.js
+++ b/frontend/packages/client/src/hooks/useAllowlist.js
@@ -1,7 +1,7 @@
-import { useReducer, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useReducer } from 'react';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { checkResponse } from 'utils';
-import { defaultReducer, INITIAL_STATE } from '../reducers';
+import { INITIAL_STATE, defaultReducer } from '../reducers';
 
 export default function useAllowlist() {
   const [state, dispatch] = useReducer(defaultReducer, INITIAL_STATE);

--- a/frontend/packages/client/src/hooks/useCommunity.js
+++ b/frontend/packages/client/src/hooks/useCommunity.js
@@ -1,12 +1,12 @@
 import { useReducer, useCallback } from 'react';
+import { useFileUploader } from 'hooks';
+import { checkResponse, getCompositeSigs } from 'utils';
+import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 import {
   paginationReducer,
   PAGINATION_INITIAL_STATE,
   INITIAL_STATE,
 } from '../reducers';
-import { checkResponse, getCompositeSigs } from 'utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
-import { useFileUploader } from 'hooks';
 
 const setDefaultValue = (field, fallbackValue) => {
   if (field === undefined || field === '') {

--- a/frontend/packages/client/src/hooks/useCommunity.js
+++ b/frontend/packages/client/src/hooks/useCommunity.js
@@ -1,11 +1,11 @@
-import { useReducer, useCallback } from 'react';
+import { useCallback, useReducer } from 'react';
+import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 import { useFileUploader } from 'hooks';
 import { checkResponse, getCompositeSigs } from 'utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 import {
-  paginationReducer,
-  PAGINATION_INITIAL_STATE,
   INITIAL_STATE,
+  PAGINATION_INITIAL_STATE,
+  paginationReducer,
 } from '../reducers';
 
 const setDefaultValue = (field, fallbackValue) => {

--- a/frontend/packages/client/src/hooks/useCommunityCategory.js
+++ b/frontend/packages/client/src/hooks/useCommunityCategory.js
@@ -1,7 +1,7 @@
 import { useReducer, useEffect, useCallback } from 'react';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { checkResponse } from 'utils';
 import { defaultReducer, INITIAL_STATE } from '../reducers';
-import { checkResponse } from '../utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 
 export default function useCommunityCategory() {
   const [state, dispatch] = useReducer(defaultReducer, INITIAL_STATE);

--- a/frontend/packages/client/src/hooks/useCommunityCategory.js
+++ b/frontend/packages/client/src/hooks/useCommunityCategory.js
@@ -1,7 +1,7 @@
-import { useReducer, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useReducer } from 'react';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { checkResponse } from 'utils';
-import { defaultReducer, INITIAL_STATE } from '../reducers';
+import { INITIAL_STATE, defaultReducer } from '../reducers';
 
 export default function useCommunityCategory() {
   const [state, dispatch] = useReducer(defaultReducer, INITIAL_STATE);

--- a/frontend/packages/client/src/hooks/useCommunityDetails.js
+++ b/frontend/packages/client/src/hooks/useCommunityDetails.js
@@ -1,8 +1,8 @@
-import { useReducer, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useReducer } from 'react';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { useWebContext } from 'contexts/Web3';
-import { defaultReducer, INITIAL_STATE } from 'reducers';
 import { checkResponse, getCompositeSigs } from 'utils';
+import { INITIAL_STATE, defaultReducer } from 'reducers';
 
 export default function useCommunityDetails(id) {
   const {

--- a/frontend/packages/client/src/hooks/useCommunityDetails.js
+++ b/frontend/packages/client/src/hooks/useCommunityDetails.js
@@ -1,8 +1,8 @@
 import { useReducer, useEffect, useCallback } from 'react';
-import { defaultReducer, INITIAL_STATE } from '../reducers';
-import { checkResponse, getCompositeSigs } from '../utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
-import { useWebContext } from '../contexts/Web3';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { useWebContext } from 'contexts/Web3';
+import { defaultReducer, INITIAL_STATE } from 'reducers';
+import { checkResponse, getCompositeSigs } from 'utils';
 
 export default function useCommunityDetails(id) {
   const {

--- a/frontend/packages/client/src/hooks/useCommunityMembers.js
+++ b/frontend/packages/client/src/hooks/useCommunityMembers.js
@@ -1,7 +1,7 @@
 import { useInfiniteQuery } from 'react-query';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { checkResponse, getPaginationInfo } from 'utils';
 import { PAGINATION_INITIAL_STATE } from '../reducers';
-import { checkResponse, getPaginationInfo } from '../utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 
 export default function useCommunityMembers({
   communityId,

--- a/frontend/packages/client/src/hooks/useCommunityProposals.js
+++ b/frontend/packages/client/src/hooks/useCommunityProposals.js
@@ -1,10 +1,10 @@
-import { useReducer, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useReducer } from 'react';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { checkResponse } from 'utils';
 import {
-  paginationReducer,
-  PAGINATION_INITIAL_STATE,
   INITIAL_STATE,
+  PAGINATION_INITIAL_STATE,
+  paginationReducer,
 } from '../reducers';
 
 /**

--- a/frontend/packages/client/src/hooks/useCommunityProposals.js
+++ b/frontend/packages/client/src/hooks/useCommunityProposals.js
@@ -1,11 +1,11 @@
 import { useReducer, useEffect, useCallback } from 'react';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { checkResponse } from 'utils';
 import {
   paginationReducer,
   PAGINATION_INITIAL_STATE,
   INITIAL_STATE,
 } from '../reducers';
-import { checkResponse } from '../utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 
 /**
  * Hook to return proposals created on a community. Results are paginated

--- a/frontend/packages/client/src/hooks/useCommunityProposalsWithVotes.js
+++ b/frontend/packages/client/src/hooks/useCommunityProposalsWithVotes.js
@@ -1,9 +1,9 @@
+import { useEffect, useMemo } from 'react';
+import { useWebContext } from 'contexts/Web3';
+import { debounce } from 'utils';
+import { PAGINATION_INITIAL_STATE } from '../reducers';
 import useCommunityProposals from './useCommunityProposals';
 import useVotesForAddress from './useVotesForAddress';
-import { PAGINATION_INITIAL_STATE } from '../reducers';
-import { useWebContext } from '../contexts/Web3';
-import { useEffect, useMemo } from 'react';
-import { debounce } from '../utils';
 
 export default function useCommunityProposalsWithVotes({
   communityId,

--- a/frontend/packages/client/src/hooks/useCommunityUsers.js
+++ b/frontend/packages/client/src/hooks/useCommunityUsers.js
@@ -1,11 +1,11 @@
 import { useReducer, useEffect, useCallback } from 'react';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { checkResponse } from 'utils';
 import {
   paginationReducer,
   PAGINATION_INITIAL_STATE,
   INITIAL_STATE,
 } from '../reducers';
-import { checkResponse } from '../utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 /**
  * Hook to return users from a community. Results are paginated
  * @param  {int} communityId community Id to get proposals from

--- a/frontend/packages/client/src/hooks/useCommunityUsers.js
+++ b/frontend/packages/client/src/hooks/useCommunityUsers.js
@@ -1,11 +1,12 @@
-import { useReducer, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useReducer } from 'react';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { checkResponse } from 'utils';
 import {
-  paginationReducer,
-  PAGINATION_INITIAL_STATE,
   INITIAL_STATE,
+  PAGINATION_INITIAL_STATE,
+  paginationReducer,
 } from '../reducers';
+
 /**
  * Hook to return users from a community. Results are paginated
  * @param  {int} communityId community Id to get proposals from

--- a/frontend/packages/client/src/hooks/useFclUser.js
+++ b/frontend/packages/client/src/hooks/useFclUser.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function useFclUser(provider, forceLedger) {
   const [user, setUser] = useState({});

--- a/frontend/packages/client/src/hooks/useFeaturedCommunities.js
+++ b/frontend/packages/client/src/hooks/useFeaturedCommunities.js
@@ -1,7 +1,7 @@
 import { useInfiniteQuery } from 'react-query';
-import { PAGINATION_INITIAL_STATE } from '../reducers';
 import { checkResponse } from 'utils';
 import { useErrorHandlerContext } from '../contexts/ErrorHandler';
+import { PAGINATION_INITIAL_STATE } from '../reducers';
 
 export default function useFeaturedCommunities({
   count = PAGINATION_INITIAL_STATE.count,

--- a/frontend/packages/client/src/hooks/useFeaturedCommunities.js
+++ b/frontend/packages/client/src/hooks/useFeaturedCommunities.js
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from 'react-query';
-import { checkResponse } from 'utils';
 import { useErrorHandlerContext } from '../contexts/ErrorHandler';
+import { checkResponse } from 'utils';
 import { PAGINATION_INITIAL_STATE } from '../reducers';
 
 export default function useFeaturedCommunities({

--- a/frontend/packages/client/src/hooks/useFileUploader.js
+++ b/frontend/packages/client/src/hooks/useFileUploader.js
@@ -1,7 +1,7 @@
 import { useReducer, useCallback } from 'react';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { checkResponse } from 'utils';
 import { defaultReducer, INITIAL_STATE } from '../reducers';
-import { checkResponse } from '../utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 
 export default function useFileUploader({ useModalNotifications = true } = {}) {
   const [state, dispatch] = useReducer(defaultReducer, {

--- a/frontend/packages/client/src/hooks/useFileUploader.js
+++ b/frontend/packages/client/src/hooks/useFileUploader.js
@@ -1,7 +1,7 @@
-import { useReducer, useCallback } from 'react';
+import { useCallback, useReducer } from 'react';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { checkResponse } from 'utils';
-import { defaultReducer, INITIAL_STATE } from '../reducers';
+import { INITIAL_STATE, defaultReducer } from '../reducers';
 
 export default function useFileUploader({ useModalNotifications = true } = {}) {
   const [state, dispatch] = useReducer(defaultReducer, {

--- a/frontend/packages/client/src/hooks/useJoinCommunity.js
+++ b/frontend/packages/client/src/hooks/useJoinCommunity.js
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from 'react-query';
-import { getCompositeSigs } from 'utils';
 import { useErrorHandlerContext } from '../contexts/ErrorHandler';
+import { getCompositeSigs } from 'utils';
 
 export default function useJoinCommunity() {
   const queryClient = useQueryClient();

--- a/frontend/packages/client/src/hooks/useJoinCommunity.js
+++ b/frontend/packages/client/src/hooks/useJoinCommunity.js
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from 'react-query';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 import { getCompositeSigs } from 'utils';
+import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 
 export default function useJoinCommunity() {
   const queryClient = useQueryClient();

--- a/frontend/packages/client/src/hooks/useLeaderBoard.js
+++ b/frontend/packages/client/src/hooks/useLeaderBoard.js
@@ -1,6 +1,6 @@
 import { useQuery } from 'react-query';
-import fetchLeaderBoard from 'api/leaderboard';
 import { useErrorHandlerContext } from '../contexts/ErrorHandler';
+import fetchLeaderBoard from 'api/leaderboard';
 
 export default function useLeaderBoard({ communityId = 0, addr = '' } = {}) {
   const { notifyError } = useErrorHandlerContext();

--- a/frontend/packages/client/src/hooks/useLeaderBoard.js
+++ b/frontend/packages/client/src/hooks/useLeaderBoard.js
@@ -1,6 +1,6 @@
 import { useQuery } from 'react-query';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 import fetchLeaderBoard from 'api/leaderboard';
+import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 
 export default function useLeaderBoard({ communityId = 0, addr = '' } = {}) {
   const { notifyError } = useErrorHandlerContext();

--- a/frontend/packages/client/src/hooks/useProposal.js
+++ b/frontend/packages/client/src/hooks/useProposal.js
@@ -1,9 +1,9 @@
 import { useReducer, useCallback } from 'react';
-import { defaultReducer, INITIAL_STATE } from '../reducers';
-import { checkResponse, getCompositeSigs } from '../utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 import { CODE as transferTokensCode } from '@onflow/six-transfer-tokens';
 import * as t from '@onflow/types';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { checkResponse, getCompositeSigs } from 'utils';
+import { defaultReducer, INITIAL_STATE } from '../reducers';
 
 export default function useProposal() {
   const [state, dispatch] = useReducer(defaultReducer, {

--- a/frontend/packages/client/src/hooks/useProposal.js
+++ b/frontend/packages/client/src/hooks/useProposal.js
@@ -1,9 +1,9 @@
-import { useReducer, useCallback } from 'react';
-import { CODE as transferTokensCode } from '@onflow/six-transfer-tokens';
-import * as t from '@onflow/types';
+import { useCallback, useReducer } from 'react';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { checkResponse, getCompositeSigs } from 'utils';
-import { defaultReducer, INITIAL_STATE } from '../reducers';
+import { CODE as transferTokensCode } from '@onflow/six-transfer-tokens';
+import * as t from '@onflow/types';
+import { INITIAL_STATE, defaultReducer } from '../reducers';
 
 export default function useProposal() {
   const [state, dispatch] = useReducer(defaultReducer, {

--- a/frontend/packages/client/src/hooks/useProposalVotes.js
+++ b/frontend/packages/client/src/hooks/useProposalVotes.js
@@ -1,11 +1,11 @@
 import { useReducer, useEffect, useCallback } from 'react';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { checkResponse } from 'utils';
 import {
   paginationReducer,
   PAGINATION_INITIAL_STATE,
   INITIAL_STATE,
 } from '../reducers';
-import { checkResponse } from '../utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 
 /**
  * Hook to return proposal votes for a proposal. Results are paginated

--- a/frontend/packages/client/src/hooks/useProposalVotes.js
+++ b/frontend/packages/client/src/hooks/useProposalVotes.js
@@ -1,10 +1,10 @@
-import { useReducer, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useReducer } from 'react';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { checkResponse } from 'utils';
 import {
-  paginationReducer,
-  PAGINATION_INITIAL_STATE,
   INITIAL_STATE,
+  PAGINATION_INITIAL_STATE,
+  paginationReducer,
 } from '../reducers';
 
 /**

--- a/frontend/packages/client/src/hooks/useStarAnimation.js
+++ b/frontend/packages/client/src/hooks/useStarAnimation.js
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-
 import { useWindowDimensions } from 'hooks';
 
 export default function useStarAnimation({ stars }) {

--- a/frontend/packages/client/src/hooks/useUserCommunities.js
+++ b/frontend/packages/client/src/hooks/useUserCommunities.js
@@ -1,7 +1,7 @@
 import { useInfiniteQuery } from 'react-query';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { checkResponse, getPaginationInfo } from 'utils';
 import { PAGINATION_INITIAL_STATE } from '../reducers';
-import { checkResponse, getPaginationInfo } from '../utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 
 export default function useUserCommunities({
   addr,

--- a/frontend/packages/client/src/hooks/useVotesForAddress.js
+++ b/frontend/packages/client/src/hooks/useVotesForAddress.js
@@ -1,6 +1,6 @@
-import { useReducer, useCallback } from 'react';
+import { useCallback, useReducer } from 'react';
 import { checkResponse } from 'utils';
-import { defaultReducer, INITIAL_STATE } from '../reducers';
+import { INITIAL_STATE, defaultReducer } from '../reducers';
 
 export default function useVotesForAddress() {
   const [state, dispatch] = useReducer(defaultReducer, {

--- a/frontend/packages/client/src/hooks/useVotesForAddress.js
+++ b/frontend/packages/client/src/hooks/useVotesForAddress.js
@@ -1,6 +1,6 @@
 import { useReducer, useCallback } from 'react';
+import { checkResponse } from 'utils';
 import { defaultReducer, INITIAL_STATE } from '../reducers';
-import { checkResponse } from '../utils';
 
 export default function useVotesForAddress() {
   const [state, dispatch] = useReducer(defaultReducer, {

--- a/frontend/packages/client/src/hooks/useVotingResults.js
+++ b/frontend/packages/client/src/hooks/useVotingResults.js
@@ -1,7 +1,7 @@
-import { useReducer, useEffect, useCallback } from 'react';
-import { checkResponse } from 'utils';
+import { useCallback, useEffect, useReducer } from 'react';
 import { useErrorHandlerContext } from '../contexts/ErrorHandler';
-import { defaultReducer, INITIAL_STATE } from '../reducers';
+import { checkResponse } from 'utils';
+import { INITIAL_STATE, defaultReducer } from '../reducers';
 
 export default function useVotingResults(proposalId) {
   const [state, dispatch] = useReducer(defaultReducer, INITIAL_STATE);

--- a/frontend/packages/client/src/hooks/useVotingResults.js
+++ b/frontend/packages/client/src/hooks/useVotingResults.js
@@ -1,7 +1,7 @@
 import { useReducer, useEffect, useCallback } from 'react';
-import { defaultReducer, INITIAL_STATE } from '../reducers';
-import { checkResponse } from '../utils';
+import { checkResponse } from 'utils';
 import { useErrorHandlerContext } from '../contexts/ErrorHandler';
+import { defaultReducer, INITIAL_STATE } from '../reducers';
 
 export default function useVotingResults(proposalId) {
   const [state, dispatch] = useReducer(defaultReducer, INITIAL_STATE);

--- a/frontend/packages/client/src/hooks/useVotingStrategies.js
+++ b/frontend/packages/client/src/hooks/useVotingStrategies.js
@@ -1,7 +1,7 @@
-import { useReducer, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useReducer } from 'react';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { checkResponse } from 'utils';
-import { defaultReducer, INITIAL_STATE } from '../reducers';
+import { INITIAL_STATE, defaultReducer } from '../reducers';
 
 export default function useVotingStrategies() {
   const [state, dispatch] = useReducer(defaultReducer, INITIAL_STATE);

--- a/frontend/packages/client/src/hooks/useVotingStrategies.js
+++ b/frontend/packages/client/src/hooks/useVotingStrategies.js
@@ -1,7 +1,7 @@
 import { useReducer, useEffect, useCallback } from 'react';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { checkResponse } from 'utils';
 import { defaultReducer, INITIAL_STATE } from '../reducers';
-import { checkResponse } from '../utils';
-import { useErrorHandlerContext } from '../contexts/ErrorHandler';
 
 export default function useVotingStrategies() {
   const [state, dispatch] = useReducer(defaultReducer, INITIAL_STATE);

--- a/frontend/packages/client/src/hooks/useWindowDimension.js
+++ b/frontend/packages/client/src/hooks/useWindowDimension.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 function getWindowDimensions() {
   const { innerWidth: width, innerHeight: height } = window;

--- a/frontend/packages/client/src/index.js
+++ b/frontend/packages/client/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import './index.css';
 import App from './App';
+import './index.css';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/packages/client/src/pages/About.js
+++ b/frontend/packages/client/src/pages/About.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { Close } from '../components/Svg';
 import { Label, ModalAboutItem } from 'components';
+import { Close } from 'components/Svg';
 
 const AboutPage = ({ location }) => {
   const { state = {} } = location;

--- a/frontend/packages/client/src/pages/Community.js
+++ b/frontend/packages/client/src/pages/Community.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
+import { useQueryClient } from 'react-query';
 import { useHistory, useParams, Link } from 'react-router-dom';
 import {
   Loader,
@@ -11,6 +12,7 @@ import {
   Tablink,
   CommunityHeader,
 } from 'components';
+import { useWebContext } from 'contexts/Web3';
 import {
   useMediaQuery,
   useCommunityDetails,
@@ -19,9 +21,7 @@ import {
   useUserRoleOnCommunity,
   useCommunityMembers,
   useWindowDimensions,
-} from '../hooks';
-import { useWebContext } from '../contexts/Web3';
-import { useQueryClient } from 'react-query';
+} from 'hooks';
 
 const CommunitySettingsButton = ({ communityId } = {}) => {
   return (

--- a/frontend/packages/client/src/pages/Community.js
+++ b/frontend/packages/client/src/pages/Community.js
@@ -1,25 +1,25 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from 'react-query';
-import { useHistory, useParams, Link } from 'react-router-dom';
-import {
-  Loader,
-  CommunityPulse,
-  CommunityLinks,
-  CommunityMemberList,
-  CommunityAbout,
-  CommunityProposals,
-  LeaderBoard,
-  Tablink,
-  CommunityHeader,
-} from 'components';
+import { Link, useHistory, useParams } from 'react-router-dom';
 import { useWebContext } from 'contexts/Web3';
 import {
-  useMediaQuery,
+  CommunityAbout,
+  CommunityHeader,
+  CommunityLinks,
+  CommunityMemberList,
+  CommunityProposals,
+  CommunityPulse,
+  LeaderBoard,
+  Loader,
+  Tablink,
+} from 'components';
+import {
   useCommunityDetails,
-  useQueryParams,
-  useCommunityUsers,
-  useUserRoleOnCommunity,
   useCommunityMembers,
+  useCommunityUsers,
+  useMediaQuery,
+  useQueryParams,
+  useUserRoleOnCommunity,
   useWindowDimensions,
 } from 'hooks';
 

--- a/frontend/packages/client/src/pages/CommunityCreate.js
+++ b/frontend/packages/client/src/pages/CommunityCreate.js
@@ -1,15 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { StepByStep, WalletConnect, Error } from 'components';
-import {
-  StartSteps,
-  StepOne,
-  StepTwo,
-  StepThree,
-  StepFour,
-} from 'components/CommunityCreate';
 import { useModalContext } from 'contexts/NotificationModal';
 import { useWebContext } from 'contexts/Web3';
+import { Error, StepByStep, WalletConnect } from 'components';
+import {
+  StartSteps,
+  StepFour,
+  StepOne,
+  StepThree,
+  StepTwo,
+} from 'components/CommunityCreate';
 import useCommunity from 'hooks/useCommunity';
 import { generateSlug } from 'utils';
 

--- a/frontend/packages/client/src/pages/CommunityCreate.js
+++ b/frontend/packages/client/src/pages/CommunityCreate.js
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { StepByStep, WalletConnect, Error } from 'components';
-import { useWebContext } from 'contexts/Web3';
-import { useModalContext } from 'contexts/NotificationModal';
 import {
   StartSteps,
   StepOne,
@@ -10,6 +8,8 @@ import {
   StepThree,
   StepFour,
 } from 'components/CommunityCreate';
+import { useModalContext } from 'contexts/NotificationModal';
+import { useWebContext } from 'contexts/Web3';
 import useCommunity from 'hooks/useCommunity';
 import { generateSlug } from 'utils';
 

--- a/frontend/packages/client/src/pages/CommunityEditor.js
+++ b/frontend/packages/client/src/pages/CommunityEditor.js
@@ -1,22 +1,22 @@
-import React, { useState, useCallback, useEffect } from 'react';
-import { Link, useParams, useHistory } from 'react-router-dom';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Link, useHistory, useParams } from 'react-router-dom';
+import { useWebContext } from 'contexts/Web3';
 import {
-  CommunityEditorProfile,
-  CommunityEditorLinks,
   CommunityEditorDetails,
+  CommunityEditorLinks,
+  CommunityEditorProfile,
   CommunityPropsAndVoting,
   Dropdown,
   Loader,
 } from 'components';
 import { ArrowLeft, ArrowLeftBold } from 'components/Svg';
-import { CommunityEditPageTabs } from 'const';
-import { useWebContext } from 'contexts/Web3';
 import {
   useCommunityDetails,
-  useMediaQuery,
   useFileUploader,
+  useMediaQuery,
   useUserRoleOnCommunity,
 } from 'hooks';
+import { CommunityEditPageTabs } from 'const';
 
 const MenuTabs = ({ tabs, communityId, onClickButtonTab = () => {} } = {}) => {
   return (

--- a/frontend/packages/client/src/pages/CommunityEditor.js
+++ b/frontend/packages/client/src/pages/CommunityEditor.js
@@ -1,6 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Link, useParams, useHistory } from 'react-router-dom';
-import { useWebContext } from 'contexts/Web3';
 import {
   CommunityEditorProfile,
   CommunityEditorLinks,
@@ -10,13 +9,14 @@ import {
   Loader,
 } from 'components';
 import { ArrowLeft, ArrowLeftBold } from 'components/Svg';
+import { CommunityEditPageTabs } from 'const';
+import { useWebContext } from 'contexts/Web3';
 import {
   useCommunityDetails,
   useMediaQuery,
   useFileUploader,
   useUserRoleOnCommunity,
 } from 'hooks';
-import { CommunityEditPageTabs } from 'const';
 
 const MenuTabs = ({ tabs, communityId, onClickButtonTab = () => {} } = {}) => {
   return (

--- a/frontend/packages/client/src/pages/Home.js
+++ b/frontend/packages/client/src/pages/Home.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import classnames from 'classnames';
-import { Loader, FadeIn, HomeFooter, HomeHeader } from 'components';
-import CommunitiesPresenter from 'components/Community/CommunitiesPresenter';
 import { useWebContext } from 'contexts/Web3';
+import { FadeIn, HomeFooter, HomeHeader, Loader } from 'components';
+import CommunitiesPresenter from 'components/Community/CommunitiesPresenter';
 import useFeaturedCommunities from 'hooks/useFeaturedCommunities';
 import useUserCommunities from 'hooks/useUserCommunities';
+import classnames from 'classnames';
 
 export default function HomePage() {
   const {

--- a/frontend/packages/client/src/pages/Home.js
+++ b/frontend/packages/client/src/pages/Home.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import classnames from 'classnames';
 import { Loader, FadeIn, HomeFooter, HomeHeader } from 'components';
-import { useWebContext } from 'contexts/Web3';
 import CommunitiesPresenter from 'components/Community/CommunitiesPresenter';
-import useUserCommunities from 'hooks/useUserCommunities';
+import { useWebContext } from 'contexts/Web3';
 import useFeaturedCommunities from 'hooks/useFeaturedCommunities';
+import useUserCommunities from 'hooks/useUserCommunities';
 
 export default function HomePage() {
   const {

--- a/frontend/packages/client/src/pages/Proposal.js
+++ b/frontend/packages/client/src/pages/Proposal.js
@@ -1,31 +1,31 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useParams, useLocation } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { useModalContext } from 'contexts/NotificationModal';
+import { useWebContext } from 'contexts/Web3';
 import {
-  Message,
-  VotesList,
-  StrategyModal,
-  ProposalInformation,
-  WalletConnect,
   Error,
   Loader,
-  WrapperResponsive,
+  Message,
+  ProposalInformation,
+  StrategyModal,
   Tablink,
+  VotesList,
+  WalletConnect,
+  WrapperResponsive,
 } from 'components';
 import {
   CancelProposalModalConfirmation,
   ProposalStatus,
   VoteOptions,
 } from 'components/Proposal';
-import { CheckMark, ArrowLeft, Bin } from 'components/Svg';
-import { FilterValues } from 'const';
-import { useModalContext } from 'contexts/NotificationModal';
-import { useWebContext } from 'contexts/Web3';
+import { ArrowLeft, Bin, CheckMark } from 'components/Svg';
 import {
-  useProposal,
-  useVotingStrategies,
   useMediaQuery,
+  useProposal,
   useUserRoleOnCommunity,
+  useVotingStrategies,
 } from 'hooks';
+import { FilterValues } from 'const';
 import { getProposalType } from 'utils';
 
 function useQueryParams() {

--- a/frontend/packages/client/src/pages/Proposal.js
+++ b/frontend/packages/client/src/pages/Proposal.js
@@ -11,21 +11,21 @@ import {
   WrapperResponsive,
   Tablink,
 } from 'components';
+import {
+  CancelProposalModalConfirmation,
+  ProposalStatus,
+  VoteOptions,
+} from 'components/Proposal';
 import { CheckMark, ArrowLeft, Bin } from 'components/Svg';
+import { FilterValues } from 'const';
+import { useModalContext } from 'contexts/NotificationModal';
+import { useWebContext } from 'contexts/Web3';
 import {
   useProposal,
   useVotingStrategies,
   useMediaQuery,
   useUserRoleOnCommunity,
 } from 'hooks';
-import { useModalContext } from 'contexts/NotificationModal';
-import { useWebContext } from 'contexts/Web3';
-import { FilterValues } from 'const';
-import {
-  CancelProposalModalConfirmation,
-  ProposalStatus,
-  VoteOptions,
-} from 'components/Proposal';
 import { getProposalType } from 'utils';
 
 function useQueryParams() {

--- a/frontend/packages/client/src/pages/ProposalCreate.js
+++ b/frontend/packages/client/src/pages/ProposalCreate.js
@@ -2,16 +2,16 @@
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { StepByStep, WalletConnect, Error } from 'components';
-import { useWebContext } from 'contexts/Web3';
-import { useModalContext } from 'contexts/NotificationModal';
-import { useErrorHandlerContext } from 'contexts/ErrorHandler';
-import { useProposal, useQueryParams } from 'hooks';
-import { parseDateToServer, customDraftToHTML } from 'utils';
 import {
   PropCreateStepOne,
   PropCreateStepTwo,
   PropCreateStepThree,
 } from 'components/ProposalCreate';
+import { useErrorHandlerContext } from 'contexts/ErrorHandler';
+import { useModalContext } from 'contexts/NotificationModal';
+import { useWebContext } from 'contexts/Web3';
+import { useProposal, useQueryParams } from 'hooks';
+import { parseDateToServer, customDraftToHTML } from 'utils';
 
 export default function ProposalCreatePage() {
   const { createProposal, data, loading, error } = useProposal();

--- a/frontend/packages/client/src/pages/ProposalCreate.js
+++ b/frontend/packages/client/src/pages/ProposalCreate.js
@@ -1,17 +1,17 @@
 /* global plausible */
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { StepByStep, WalletConnect, Error } from 'components';
-import {
-  PropCreateStepOne,
-  PropCreateStepTwo,
-  PropCreateStepThree,
-} from 'components/ProposalCreate';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { useModalContext } from 'contexts/NotificationModal';
 import { useWebContext } from 'contexts/Web3';
+import { Error, StepByStep, WalletConnect } from 'components';
+import {
+  PropCreateStepOne,
+  PropCreateStepThree,
+  PropCreateStepTwo,
+} from 'components/ProposalCreate';
 import { useProposal, useQueryParams } from 'hooks';
-import { parseDateToServer, customDraftToHTML } from 'utils';
+import { customDraftToHTML, parseDateToServer } from 'utils';
 
 export default function ProposalCreatePage() {
   const { createProposal, data, loading, error } = useProposal();

--- a/frontend/packages/client/src/pages/index.js
+++ b/frontend/packages/client/src/pages/index.js
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy } from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import Loader from 'components/Loader';
 
 const Header = lazy(() => import('components/Header'));

--- a/frontend/packages/client/src/pages/index.js
+++ b/frontend/packages/client/src/pages/index.js
@@ -1,9 +1,9 @@
 import React, { Suspense, lazy } from 'react';
 import { Switch, Route } from 'react-router-dom';
-import Loader from '../components/Loader';
+import Loader from 'components/Loader';
 
-const Header = lazy(() => import('../components/Header'));
-const Transactions = lazy(() => import('../components/Transactions'));
+const Header = lazy(() => import('components/Header'));
+const Transactions = lazy(() => import('components/Transactions'));
 const Home = lazy(() => import('./Home'));
 const Proposal = lazy(() => import('./Proposal'));
 const About = lazy(() => import('./About'));

--- a/frontend/packages/client/src/pages/pages.test.js
+++ b/frontend/packages/client/src/pages/pages.test.js
@@ -1,10 +1,8 @@
-import { render, cleanup, waitFor } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
-
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
 import '@testing-library/jest-dom';
-
 import AppPages from '.';
 
 jest.mock('../components/Transactions', () => () => {
@@ -33,7 +31,7 @@ jest.mock('./ProposalCreate', () => () => {
 });
 
 afterAll(() => {
-  jest.unmock('../components/Transactions');
+  jest.unmock('components/Transactions');
   jest.unmock('./Home');
   jest.unmock('./About');
   jest.unmock('./Community');

--- a/frontend/packages/client/src/pages/pages.test.js
+++ b/frontend/packages/client/src/pages/pages.test.js
@@ -1,8 +1,8 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { Router } from 'react-router-dom';
-import { render, cleanup, waitFor } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
 import '@testing-library/jest-dom';
+import { createMemoryHistory } from 'history';
 import AppPages from '.';
 
 jest.mock('../components/Transactions', () => () => {

--- a/frontend/packages/client/src/utils.js
+++ b/frontend/packages/client/src/utils.js
@@ -1,6 +1,6 @@
 import { formatDistance } from 'date-fns';
-import { customAlphabet } from 'nanoid';
 import { stateToHTML } from 'draft-js-export-html';
+import { customAlphabet } from 'nanoid';
 
 const nanoid = customAlphabet('1234567890abcdef', 10);
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ampproject/remapping@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
+  integrity sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.1.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@babel/code-frame@7.10.4":
   version "7.10.4"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz"
@@ -23,10 +31,22 @@
   dependencies:
     "@babel/highlight" "^7.16.0"
 
+"@babel/code-frame@^7.16.7", "@babel/code-frame@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
+  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
+  dependencies:
+    "@babel/highlight" "^7.18.6"
+
 "@babel/compat-data@^7.12.1", "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.16.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.0.tgz"
   integrity sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew==
+
+"@babel/compat-data@^7.18.8":
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.8.tgz#2483f565faca607b8535590e84e7de323f27764d"
+  integrity sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==
 
 "@babel/core@7.12.3", "@babel/core@^7.1.0":
   version "7.12.3"
@@ -50,6 +70,27 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@7.17.8":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.8.tgz#3dac27c190ebc3a4381110d46c80e77efe172e1a"
+  integrity sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==
+  dependencies:
+    "@ampproject/remapping" "^2.1.0"
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.7"
+    "@babel/helper-compilation-targets" "^7.17.7"
+    "@babel/helper-module-transforms" "^7.17.7"
+    "@babel/helpers" "^7.17.8"
+    "@babel/parser" "^7.17.8"
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.17.3"
+    "@babel/types" "^7.17.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+
 "@babel/core@^7.12.3", "@babel/core@^7.7.5", "@babel/core@^7.8.4":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz"
@@ -71,6 +112,15 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
+"@babel/generator@7.17.7":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.7.tgz#8da2599beb4a86194a3b24df6c085931d9ee45ad"
+  integrity sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==
+  dependencies:
+    "@babel/types" "^7.17.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.12.1", "@babel/generator@^7.16.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz"
@@ -79,6 +129,15 @@
     "@babel/types" "^7.16.0"
     jsesc "^2.5.1"
     source-map "^0.5.0"
+
+"@babel/generator@^7.17.3", "@babel/generator@^7.17.7", "@babel/generator@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.9.tgz#68337e9ea8044d6ddc690fb29acae39359cca0a5"
+  integrity sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==
+  dependencies:
+    "@babel/types" "^7.18.9"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
 
 "@babel/helper-annotate-as-pure@^7.16.0":
   version "7.16.0"
@@ -103,6 +162,16 @@
     "@babel/compat-data" "^7.16.0"
     "@babel/helper-validator-option" "^7.14.5"
     browserslist "^4.16.6"
+    semver "^6.3.0"
+
+"@babel/helper-compilation-targets@^7.17.7":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz#69e64f57b524cde3e5ff6cc5a9f4a387ee5563bf"
+  integrity sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==
+  dependencies:
+    "@babel/compat-data" "^7.18.8"
+    "@babel/helper-validator-option" "^7.18.6"
+    browserslist "^4.20.2"
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.12.1", "@babel/helper-create-class-features-plugin@^7.16.0":
@@ -139,6 +208,11 @@
     resolve "^1.14.2"
     semver "^6.1.2"
 
+"@babel/helper-environment-visitor@^7.16.7", "@babel/helper-environment-visitor@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
+  integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
+
 "@babel/helper-explode-assignable-expression@^7.16.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.0.tgz"
@@ -155,6 +229,14 @@
     "@babel/template" "^7.16.0"
     "@babel/types" "^7.16.0"
 
+"@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz#940e6084a55dee867d33b4e487da2676365e86b0"
+  integrity sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==
+  dependencies:
+    "@babel/template" "^7.18.6"
+    "@babel/types" "^7.18.9"
+
 "@babel/helper-get-function-arity@^7.16.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz"
@@ -168,6 +250,13 @@
   integrity sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-hoist-variables@^7.16.7", "@babel/helper-hoist-variables@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
+  integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
+  dependencies:
+    "@babel/types" "^7.18.6"
 
 "@babel/helper-member-expression-to-functions@^7.16.0":
   version "7.16.0"
@@ -183,6 +272,13 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-module-imports@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
+  integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
 "@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.16.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz"
@@ -196,6 +292,20 @@
     "@babel/template" "^7.16.0"
     "@babel/traverse" "^7.16.0"
     "@babel/types" "^7.16.0"
+
+"@babel/helper-module-transforms@^7.17.7":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz#5a1079c005135ed627442df31a42887e80fcb712"
+  integrity sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-simple-access" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.18.6"
+    "@babel/template" "^7.18.6"
+    "@babel/traverse" "^7.18.9"
+    "@babel/types" "^7.18.9"
 
 "@babel/helper-optimise-call-expression@^7.16.0":
   version "7.16.0"
@@ -235,6 +345,13 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-simple-access@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz#d6d8f51f4ac2978068df934b569f08f29788c7ea"
+  integrity sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.12.1", "@babel/helper-skip-transparent-expression-wrappers@^7.16.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz"
@@ -249,15 +366,32 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-split-export-declaration@^7.16.7", "@babel/helper-split-export-declaration@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz#7367949bc75b20c6d5a5d4a97bba2824ae8ef075"
+  integrity sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
 "@babel/helper-validator-identifier@^7.15.7":
   version "7.15.7"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
+"@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
+  integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
+
 "@babel/helper-validator-option@^7.12.1", "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
   resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz"
   integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
+
+"@babel/helper-validator-option@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
+  integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
 
 "@babel/helper-wrap-function@^7.16.0":
   version "7.16.0"
@@ -278,6 +412,15 @@
     "@babel/traverse" "^7.16.0"
     "@babel/types" "^7.16.0"
 
+"@babel/helpers@^7.17.8":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.18.9.tgz#4bef3b893f253a1eced04516824ede94dcfe7ff9"
+  integrity sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==
+  dependencies:
+    "@babel/template" "^7.18.6"
+    "@babel/traverse" "^7.18.9"
+    "@babel/types" "^7.18.9"
+
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.16.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz"
@@ -287,10 +430,29 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
+  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.18.6"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/parser@7.17.8":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.8.tgz#2817fb9d885dd8132ea0f8eb615a6388cca1c240"
+  integrity sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.12.3", "@babel/parser@^7.14.7", "@babel/parser@^7.16.0", "@babel/parser@^7.7.0":
   version "7.16.2"
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz"
   integrity sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==
+
+"@babel/parser@^7.17.3", "@babel/parser@^7.17.8", "@babel/parser@^7.18.6", "@babel/parser@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.9.tgz#f2dde0c682ccc264a9a8595efd030a5cc8fd2539"
+  integrity sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.0":
   version "7.16.2"
@@ -1209,6 +1371,31 @@
     "@babel/parser" "^7.16.0"
     "@babel/types" "^7.16.0"
 
+"@babel/template@^7.16.7", "@babel/template@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.6.tgz#1283f4993e00b929d6e2d3c72fdc9168a2977a31"
+  integrity sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/parser" "^7.18.6"
+    "@babel/types" "^7.18.6"
+
+"@babel/traverse@7.17.3":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
+  integrity sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.3"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.17.3"
+    "@babel/types" "^7.17.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.12.1", "@babel/traverse@^7.13.0", "@babel/traverse@^7.16.0", "@babel/traverse@^7.7.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz"
@@ -1224,12 +1411,44 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.17.3", "@babel/traverse@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.9.tgz#deeff3e8f1bad9786874cb2feda7a2d77a904f98"
+  integrity sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.18.9"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.18.9"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.18.9"
+    "@babel/types" "^7.18.9"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/types@7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
+  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.6", "@babel/types@^7.16.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz"
   integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.15.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.17.0", "@babel/types@^7.18.6", "@babel/types@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.9.tgz#7148d64ba133d8d73a41b3172ac4b83a1452205f"
+  integrity sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -1512,6 +1731,46 @@
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
+
+"@jridgewell/gen-mapping@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
+  integrity sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.0"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/gen-mapping@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
+  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+
+"@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
+  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz#b231a081d8f66796e475ad588a1ef473112701ed"
+  integrity sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1905,6 +2164,19 @@
   version "1.1.2"
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@trivago/prettier-plugin-sort-imports@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.3.0.tgz#ee4e9ec1d8e3076b95fcb94311f42f7a61eecd37"
+  integrity sha512-1y44bVZuIN0RsS3oIiGd5k8Vm3IZXYZnp4VsP2Z/S5L9WAOw43HE2clso66M2S/dDeJ+8sKPqnHsEfh39Vjs3w==
+  dependencies:
+    "@babel/core" "7.17.8"
+    "@babel/generator" "7.17.7"
+    "@babel/parser" "7.17.8"
+    "@babel/traverse" "7.17.3"
+    "@babel/types" "7.17.0"
+    javascript-natural-sort "0.7.1"
+    lodash "4.17.21"
 
 "@types/aria-query@^4.2.0":
   version "4.2.2"
@@ -3234,6 +3506,16 @@ browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.16.6, browserslist@^4
     node-releases "^2.0.1"
     picocolors "^1.0.0"
 
+browserslist@^4.20.2:
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.3.tgz#5df277694eb3c48bc5c4b05af3e8b7e09c5a6d1a"
+  integrity sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==
+  dependencies:
+    caniuse-lite "^1.0.30001370"
+    electron-to-chromium "^1.4.202"
+    node-releases "^2.0.6"
+    update-browserslist-db "^1.0.5"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz"
@@ -3427,6 +3709,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, can
   version "1.0.30001278"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001278.tgz"
   integrity sha512-mpF9KeH8u5cMoEmIic/cr7PNS+F5LWBk0t2ekGT60lFf0Wq+n9LspAj0g3P+o7DQhD3sUdlMln4YFAWhFYn9jg==
+
+caniuse-lite@^1.0.30001370:
+  version "1.0.30001373"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz#2dc3bc3bfcb5d5a929bec11300883040d7b4b4be"
+  integrity sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -4612,6 +4899,11 @@ electron-to-chromium@^1.3.564, electron-to-chromium@^1.3.886:
   version "1.3.891"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.891.tgz"
   integrity sha512-3cpwR82QkIS01CN/dup/4Yr3BiOiRLlZlcAFn/5FbNCunMO9ojqDgEP9JEo1QNLflu3pEnPWve50gHOEKc7r6w==
+
+electron-to-chromium@^1.4.202:
+  version "1.4.206"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.206.tgz#580ff85b54d7ec0c05f20b1e37ea0becdd7b0ee4"
+  integrity sha512-h+Fadt1gIaQ06JaIiyqPsBjJ08fV5Q7md+V8bUvQW/9OvXfL2LRICTz2EcnnCP7QzrFTS6/27MRV6Bl9Yn97zA==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -6673,6 +6965,11 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+javascript-natural-sort@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
+  integrity sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==
+
 jest-changed-files@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz"
@@ -8027,6 +8324,11 @@ node-releases@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz"
   integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
+
+node-releases@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
+  integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -11629,6 +11931,14 @@ upath@^1.1.1, upath@^1.1.2, upath@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
+update-browserslist-db@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz#be06a5eedd62f107b7c19eb5bcefb194411abf38"
+  integrity sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
- Add prettier plugin to sort imports (updates .prettierrc)
- Add eslint rule for one component per file

This is to keep align with using Prettier for code formatting concerns, and eslint for code-quality concerns
