### PR TITLE
fix calculation when maxweight provided

### DIFF
--- a/backend/main/strategies/token_weighted_default.go
+++ b/backend/main/strategies/token_weighted_default.go
@@ -97,12 +97,13 @@ func (s *TokenWeightedDefault) TallyVotes(
 
 			if proposal.Max_weight != nil {
 				allowedBalance = proposal.EnforceMaxWeight(float64(*vote.PrimaryAccountBalance))
+				r.Results[vote.Choice] += int(allowedBalance)
+				r.Results_float[vote.Choice] += allowedBalance
 			} else {
 				allowedBalance = float64(*vote.PrimaryAccountBalance)
+				r.Results[vote.Choice] += int(allowedBalance * math.Pow(10, -8))
+				r.Results_float[vote.Choice] += allowedBalance * math.Pow(10, -8)
 			}
-
-			r.Results[vote.Choice] += int(allowedBalance * math.Pow(10, -8))
-			r.Results_float[vote.Choice] += allowedBalance * math.Pow(10, -8)
 		}
 	}
 


### PR DESCRIPTION
When a proposal has a max weight provided this will be an integer and does not need the conversion from a float stored as an integer