### PR TITLE
dev environment + results fix

### DIFF
--- a/backend/main/models/balance.go
+++ b/backend/main/models/balance.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"fmt"
 	"time"
 
 	s "github.com/DapperCollectives/CAST/backend/main/shared"
@@ -34,8 +33,6 @@ func (b *Balance) GetBalanceByAddressAndBlockHeight(db *s.Database) error {
 }
 
 func (b *Balance) CreateBalance(db *s.Database) error {
-
-	fmt.Printf("Balance %+v\n", b)
 	sql := `
 	INSERT INTO balances (addr, primary_account_balance, secondary_address,
 	    secondary_account_balance, staking_balance, script_result, stakes, block_height, id)

--- a/backend/main/models/balance.go
+++ b/backend/main/models/balance.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"time"
 
 	s "github.com/DapperCollectives/CAST/backend/main/shared"
@@ -33,17 +34,14 @@ func (b *Balance) GetBalanceByAddressAndBlockHeight(db *s.Database) error {
 }
 
 func (b *Balance) CreateBalance(db *s.Database) error {
-	// Skip for test/dev.
-	if *db.Env == "TEST" || *db.Env == "DEV" {
-		return nil
-	}
 
-	// Build SQL query to insert balances to DB
+	fmt.Printf("Balance %+v\n", b)
 	sql := `
 	INSERT INTO balances (addr, primary_account_balance, secondary_address,
 	    secondary_account_balance, staking_balance, script_result, stakes, block_height, id)
 	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`
+
 	_, err := db.Conn.Exec(db.Context, sql,
 		b.Addr, b.PrimaryAccountBalance, b.SecondaryAddress, b.SecondaryAccountBalance,
 		b.StakingBalance, b.ScriptResult, b.Stakes, b.BlockHeight, uuid.New(),

--- a/backend/main/models/proposal.go
+++ b/backend/main/models/proposal.go
@@ -227,7 +227,7 @@ func (p *Proposal) EnforceMaxWeight(balance float64) float64 {
 	var maxWeight = *p.Max_weight
 
 	//inversions is used to correctly shift Max_weight x amount of
-	//decimal places, depending on how many decimal places it original is
+	//decimal places, depending on how many decimal places it originally is
 	var inversions = map[int]int{
 		1: 8,
 		2: 7,

--- a/backend/main/models/proposal.go
+++ b/backend/main/models/proposal.go
@@ -225,6 +225,9 @@ func (p *Proposal) EnforceMaxWeight(balance float64) float64 {
 
 	var allowedBalance float64
 	var maxWeight = *p.Max_weight
+
+	//inversions is used to correctly shift Max_weight x amount of
+	//decimal places, depending on how many decimal places it original is
 	var inversions = map[int]int{
 		1: 8,
 		2: 7,

--- a/backend/main/models/proposal.go
+++ b/backend/main/models/proposal.go
@@ -223,6 +223,8 @@ func (p *Proposal) EnforceMaxWeight(balance float64) float64 {
 	if p.Max_weight == nil {
 		return balance
 	}
+	fmt.Printf("maxWeight: %f\n", maxWeight)
+	fmt.Printf("balance: %f\n", balance)
 
 	if balance >= maxWeight {
 		allowedBalance = maxWeight

--- a/backend/main/models/proposal.go
+++ b/backend/main/models/proposal.go
@@ -6,7 +6,9 @@ package models
 
 import (
 	"fmt"
+	"math"
 	"os"
+	"strings"
 	"time"
 
 	s "github.com/DapperCollectives/CAST/backend/main/shared"
@@ -217,17 +219,38 @@ func (p *Proposal) ValidateBalance(weight float64) error {
 }
 
 func (p *Proposal) EnforceMaxWeight(balance float64) float64 {
-	var allowedBalance float64
-	var maxWeight = *p.Max_weight
-
 	if p.Max_weight == nil {
 		return balance
 	}
-	fmt.Printf("maxWeight: %f\n", maxWeight)
-	fmt.Printf("balance: %f\n", balance)
 
-	if balance >= maxWeight {
-		allowedBalance = maxWeight
+	var allowedBalance float64
+	var maxWeight = *p.Max_weight
+	var inversions = map[int]int{
+		1: 8,
+		2: 7,
+		3: 6,
+		4: 5,
+		5: 4,
+		6: 3,
+		7: 2,
+		8: 1,
+	}
+
+	//we shift the maxWeight up by x decimal places so that the
+	//comparison block works as expected
+	//first, get the number of decimal places left side of . for maxWeight
+	maxLimitLength := len(strings.Split(fmt.Sprintf("%v", maxWeight), ".")[0])
+
+	minuend := inversions[maxLimitLength]
+	powerToShift := minuend - maxLimitLength
+	shiftedMaxWeight := maxWeight * math.Pow(10, float64(powerToShift))
+
+	fmt.Printf("balance: %f\n", balance)
+	fmt.Printf("shiftedMaxWeight: %f\n", shiftedMaxWeight)
+
+	if balance >= shiftedMaxWeight {
+		fmt.Printf("balance >= shiftedMaxWeight\n")
+		allowedBalance = shiftedMaxWeight
 	} else {
 		allowedBalance = balance
 	}

--- a/backend/main/models/proposal.go
+++ b/backend/main/models/proposal.go
@@ -245,11 +245,7 @@ func (p *Proposal) EnforceMaxWeight(balance float64) float64 {
 	powerToShift := minuend - maxLimitLength
 	shiftedMaxWeight := maxWeight * math.Pow(10, float64(powerToShift))
 
-	fmt.Printf("balance: %f\n", balance)
-	fmt.Printf("shiftedMaxWeight: %f\n", shiftedMaxWeight)
-
 	if balance >= shiftedMaxWeight {
-		fmt.Printf("balance >= shiftedMaxWeight\n")
 		allowedBalance = shiftedMaxWeight
 	} else {
 		allowedBalance = balance

--- a/backend/main/server/app.go
+++ b/backend/main/server/app.go
@@ -612,7 +612,6 @@ func (a *App) createVoteForProposal(w http.ResponseWriter, r *http.Request) {
 
 	s.InitStrategy(a.FlowAdapter, a.DB, a.SnapshotClient)
 
-	// TODO: should work w/ NFTs
 	balance, err := s.FetchBalance(emptyBalance, &p)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error fetching balance for address %v.", v.Addr)
@@ -1463,7 +1462,7 @@ func (a *App) getAccountAtBlockHeight(w http.ResponseWriter, r *http.Request) {
 		Name: &flowToken,
 	}
 
-	b := Balance{}
+	b := shared.FTBalanceResponse{}
 	if err = a.SnapshotClient.GetAddressBalanceAtBlockHeight(addr, blockHeight, &b, &defaultFlowContract); err != nil {
 		log.Error().Err(err).Msgf("Error getting account %s at blockheight %d.", addr, blockHeight)
 		respondWithError(w, http.StatusInternalServerError, err.Error())

--- a/backend/main/shared/snapshot-flow.go
+++ b/backend/main/shared/snapshot-flow.go
@@ -52,36 +52,19 @@ type SnapshotData struct {
 	BlockHeight uint64 `json:"blockHeight"`
 }
 
-// copied this quick and dirty from models to get around circular dependency
-// move to shared?
-type Balance struct {
-	ID                      string    `json:"id"`
-	Addr                    string    `json:"addr"`
-	PrimaryAccountBalance   uint64    `json:"primaryAccountBalance"`
-	SecondaryAddress        string    `json:"secondaryAddress"`
-	SecondaryAccountBalance uint64    `json:"secondaryAccountBalance"`
-	StakingBalance          uint64    `json:"stakingBalance"`
-	ScriptResult            string    `json:"scriptResult"`
-	Stakes                  []string  `json:"stakes"`
-	BlockHeight             uint64    `json:"blockHeight"`
-	Proposal_id             int       `json:"proposal_id"`
-	NFTCount                int       `json:"nftCount"`
-	CreatedAt               time.Time `json:"createdAt"`
-}
-
 var (
 	DummySnapshot = Snapshot{
 		ID:           "1",
-		Block_height: 1000000,
+		Block_height: 0,
 		Started:      time.Now(),
 		Finished:     time.Now(),
 	}
 
-	DummyBalance = Balance{
+	DummyBalance = FTBalanceResponse{
 		PrimaryAccountBalance:   100,
 		SecondaryAccountBalance: 100,
 		StakingBalance:          100,
-		BlockHeight:             1000000,
+		BlockHeight:             0,
 	}
 )
 
@@ -157,12 +140,14 @@ func (c *SnapshotClient) GetSnapshotStatusAtBlockHeight(
 func (c *SnapshotClient) GetAddressBalanceAtBlockHeight(
 	address string,
 	blockheight uint64,
-	balanceResponse interface{},
+	balanceResponse *FTBalanceResponse,
 	contract *Contract,
 ) error {
 	if c.bypass() {
+		log.Info().Msgf("overriding snapshotter service for dev")
 		return nil
 	}
+
 	var url string
 
 	if *contract.Name == "FlowToken" {

--- a/backend/main/shared/structs.go
+++ b/backend/main/shared/structs.go
@@ -86,9 +86,9 @@ type FTBalanceResponse struct {
 
 func (b *FTBalanceResponse) NewFTBalance() {
 	if os.Getenv("APP_ENV") == "TEST" || os.Getenv("APP_ENV") == "DEV" {
-		b.PrimaryAccountBalance = 100
-		b.SecondaryAccountBalance = 100
-		b.StakingBalance = 100
+		b.PrimaryAccountBalance = 11100000
+		b.SecondaryAccountBalance = 12300000
+		b.StakingBalance = 13500000
 	}
 }
 

--- a/backend/main/shared/structs.go
+++ b/backend/main/shared/structs.go
@@ -2,7 +2,9 @@ package shared
 
 import (
 	"context"
+	"os"
 	"reflect"
+	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 )
@@ -63,6 +65,31 @@ type MintParams struct {
 	Cuts                 []float64
 	RoyaltyDescriptions  []string
 	RoyaltyBeneficiaries []string
+}
+
+type FTBalanceResponse struct {
+	ID                      string    `json:"id,omitempty"`
+	FungibleTokenID         string    `json:"fungibleTokenId"`
+	Addr                    string    `json:"addr"`
+	PrimaryAccountBalance   uint64    `json:"primaryAccountBalance"`
+	SecondaryAddress        string    `json:"secondaryAddress"`
+	SecondaryAccountBalance uint64    `json:"secondaryAccountBalance"`
+	Balance                 uint64    `json:"balance"`
+	StakingBalance          uint64    `json:"stakingBalance"`
+	ScriptResult            string    `json:"scriptResult"`
+	Stakes                  []string  `json:"stakes"`
+	BlockHeight             uint64    `json:"blockHeight"`
+	Proposal_id             int       `json:"proposal_id"`
+	NFTCount                int       `json:"nftCount"`
+	CreatedAt               time.Time `json:"createdAt"`
+}
+
+func (b *FTBalanceResponse) NewFTBalance() {
+	if os.Getenv("APP_ENV") == "TEST" || os.Getenv("APP_ENV") == "DEV" {
+		b.PrimaryAccountBalance = 100
+		b.SecondaryAccountBalance = 100
+		b.StakingBalance = 100
+	}
 }
 
 // Underlying value of payload needs to be a slice

--- a/backend/main/strategies/staked_token_weighted_default.go
+++ b/backend/main/strategies/staked_token_weighted_default.go
@@ -31,16 +31,17 @@ func (s *StakedTokenWeightedDefault) FetchBalance(
 		log.Error().Err(err).Msg("Unable to find strategy for contract")
 		return nil, err
 	}
+	fmt.Printf("strategy: %+v\n", strategy)
 
-	if err := s.SC.GetAddressBalanceAtBlockHeight(
-		b.Addr,
-		b.BlockHeight,
-		b,
-		&strategy.Contract,
-	); err != nil {
-		log.Error().Err(err).Msg("Error fetching balance.")
-		return nil, err
-	}
+	// if err := s.SC.GetAddressBalanceAtBlockHeight(
+	// 	b.Addr,
+	// 	b.BlockHeight,
+	// 	b,
+	// 	&strategy.Contract,
+	// ); err != nil {
+	// 	log.Error().Err(err).Msg("Error fetching balance.")
+	// 	return nil, err
+	// }
 
 	if err := b.CreateBalance(s.DB); err != nil {
 		log.Error().Err(err).Msg("Error creating balance in the database.")

--- a/backend/main/strategies/staked_token_weighted_default.go
+++ b/backend/main/strategies/staked_token_weighted_default.go
@@ -31,18 +31,11 @@ func (s *StakedTokenWeightedDefault) FetchBalance(
 		log.Error().Err(err).Msg("Unable to find strategy for contract")
 		return nil, err
 	}
-	fmt.Printf("strategy: %+v\n", strategy)
 
-	// if err := s.SC.GetAddressBalanceAtBlockHeight(
-	// 	b.Addr,
-	// 	b.BlockHeight,
-	// 	b,
-	// 	&strategy.Contract,
-	// ); err != nil {
-	// 	log.Error().Err(err).Msg("Error fetching balance.")
-	// 	return nil, err
-	// }
-
+	if err := s.FetchBalanceFromSnapshot(&strategy, b); err != nil {
+		log.Error().Err(err).Msg("Error calling snapshot client")
+		return nil, err
+	}
 	if err := b.CreateBalance(s.DB); err != nil {
 		log.Error().Err(err).Msg("Error creating balance in the database.")
 		return nil, err
@@ -51,6 +44,45 @@ func (s *StakedTokenWeightedDefault) FetchBalance(
 	return b, nil
 }
 
+func (s *StakedTokenWeightedDefault) FetchBalanceFromSnapshot(
+	strategy *models.Strategy,
+	b *models.Balance,
+) error {
+
+	var ftBalance = &shared.FTBalanceResponse{}
+	ftBalance.NewFTBalance()
+
+	if *strategy.Contract.Name == "FlowToken" {
+		if err := s.SC.GetAddressBalanceAtBlockHeight(
+			b.Addr,
+			b.BlockHeight,
+			ftBalance,
+			&strategy.Contract,
+		); err != nil {
+			log.Error().Err(err).Msg("Error fetching balance from snapshot client")
+			return err
+		}
+		b.PrimaryAccountBalance = ftBalance.PrimaryAccountBalance
+		b.SecondaryAccountBalance = ftBalance.SecondaryAccountBalance
+		b.StakingBalance = ftBalance.StakingBalance
+
+	} else {
+		if err := s.SC.GetAddressBalanceAtBlockHeight(
+			b.Addr,
+			b.BlockHeight,
+			ftBalance,
+			&strategy.Contract,
+		); err != nil {
+			log.Error().Err(err).Msg("Error fetching balance.")
+			return err
+		}
+		b.PrimaryAccountBalance = ftBalance.Balance
+		b.SecondaryAccountBalance = 0
+		b.StakingBalance = 0
+	}
+
+	return nil
+}
 func (s *StakedTokenWeightedDefault) TallyVotes(
 	votes []*models.VoteWithBalance,
 	r *models.ProposalResults,

--- a/backend/main/strategies/token_weighted_default.go
+++ b/backend/main/strategies/token_weighted_default.go
@@ -84,6 +84,8 @@ func (s *TokenWeightedDefault) TallyVotes(
 	proposal *models.Proposal,
 ) (models.ProposalResults, error) {
 
+	fmt.Printf("Proposal %v\n", proposal)
+
 	for _, vote := range votes {
 
 		if vote.PrimaryAccountBalance != nil {


### PR DESCRIPTION
This PR fixes two issues. 

- `EnforceMaxWeight` was not comparing balance against `proposal.Max_weight` correctly 
- Local dev was not updating balances to the DB because of snapshot balance fetch override. 

Changes made
• Adds new algorithm to convert balances of `uint64` to float, with the correct decimal place shifts
* Sends back a dummy balance on `FetchBalanceFromSnapshot`, 
* Adds new function inside `token-weighted-default` and `staked-token-weighted-default`, `FetchBalanceFromSnapshot`, this cleans up `FetchBalance` quite a lot. 
* Moves `FTBalanceResponse` Struct into shared. 
* Uses that same struct for both FT and Flow Token responses from snapshotter
* Adds constructor `NewFTBalance()`, this is required if you want to update a struct by reference within another function, its fields need to be initialised. 

Results being calculated correctly. And `Max_weight` being applied correctly in my manual tests. 

<img width="513" alt="Screenshot 2022-08-03 at 14 04 29" src="https://user-images.githubusercontent.com/35300528/182604592-61718ddf-1241-432b-99d2-ff997ffe29d1.png">

**Improvements**
There are many possible edge cases which are hard to test manually, I think unit tests would be the safest way to go here, as this functionality is so critical. 

This breaks our tests suite currently for all the `TallyVotes` methods, as `dummyBalance` is now being generated `SnapshotClient.GetAddressBalanceAtBlockHeight`

**Notes**
I fiddled with the how the results are being returned, but many variations caused the front end not to render results correctly, with the current setup it seems to work as expected. 

