### PR TITLE
cas-404 bypass ipfs with dummy vals for local dev 

### DIFF
--- a/backend/main/shared/ipfs.go
+++ b/backend/main/shared/ipfs.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -101,6 +102,12 @@ func (c *IpfsClient) PinJson(data interface{}) (*Pin, error) {
 }
 
 func (c *IpfsClient) PinFile(file multipart.File, fileName string) (*Pin, error) {
+	if c.bypass() {
+		return &Pin{
+			IpfsHash:  "local-host",
+			Timestamp: time.Now(),
+		}, nil
+	}
 	url := c.BaseURL + "/pinning/pinFileToIPFS"
 
 	body := &bytes.Buffer{}
@@ -119,4 +126,11 @@ func (c *IpfsClient) PinFile(file multipart.File, fileName string) (*Pin, error)
 	}
 
 	return &res, nil
+}
+
+func (c *IpfsClient) bypass() bool {
+	if os.Getenv("APP_ENV") == "DEV" {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
• adds `bypass` method on ipfs client. This is to stop the flaky ipfs responses I've been getting on various wifis.