### PR TITLE
CAS-393: Handle voting and achievements for cancelled proposals

### DIFF
--- a/backend/main/models/community_users.go
+++ b/backend/main/models/community_users.go
@@ -323,7 +323,7 @@ func getUserAchievements(db *s.Database, communityId int) (UserAchievements, err
 				ORDER BY 1,2$$
 			) AS ct(address varchar(18), winning_vote bigint)
 		) c ON v.addr = c.address
-			WHERE p.community_id = $1
+			WHERE p.community_id = $1 AND v.is_cancelled != 'true'
 			GROUP BY v.addr, a.early_vote, b.streak, c.winning_vote
 		`, communityId, communityId, communityId)
 

--- a/backend/main/models/proposal.go
+++ b/backend/main/models/proposal.go
@@ -171,6 +171,13 @@ func (p *Proposal) UpdateProposal(db *s.Database) error {
 		return err
 	}
 
+	if *p.Status == "cancelled" {
+		err := handleCancelledProposal(db, p.ID)
+		if err != nil {
+			return err
+		}
+	}
+
 	err = p.GetProposalById(db)
 	return err
 }
@@ -290,4 +297,86 @@ func GetActiveStrategiesForCommunity(db *s.Database, communityId int) ([]string,
 	}
 
 	return strategies, nil
+}
+
+func handleCancelledProposal(db *s.Database, proposalId int) error {
+
+	// Delete All votes for cancelled proposal
+	_, err := db.Conn.Exec(db.Context, `
+		DELETE FROM votes WHERE proposal_id = $1
+	`, proposalId)
+
+	if err != nil {
+		return err
+	}
+
+	// Delete All non-streak achievements
+	_, err = db.Conn.Exec(db.Context, `
+		DELETE FROM user_achievements WHERE $1 = ANY (proposals) AND achievement_type != 'streak'
+	`, proposalId)
+
+	if err != nil {
+		return err
+	}
+
+	var achievements = []struct {
+		Id int64 `json:"id"`
+		Proposals []int64 `json:"proposals"`
+		Details string `json:"details"`
+	}{}
+
+	// handle streaks
+	err = pgxscan.Select(db.Context, db.Conn, &achievements, `
+		SELECT id, proposals, details FROM user_achievements WHERE $1 = ANY (proposals) AND achievement_type = 'streak'
+	`, proposalId)
+
+	if err != nil && err.Error() != pgx.ErrNoRows.Error() {
+		return err
+	}
+
+	for _, a := range achievements {
+		pId := int64(proposalId)
+	
+	  	// Find index of proposal id being cancelled
+		index := -1
+		for i, id := range a.Proposals {
+			if id == pId {
+				index = i
+				break
+			}
+		}
+
+		// Remove proposalId from array
+		copy(a.Proposals[index:], a.Proposals[index+1:])
+		a.Proposals = a.Proposals[:len(a.Proposals)-1]
+
+		// NOTE: If cancelled proposal is in the middle of a streak greater than 3, the user will maintain
+		// their streak, but it will be one less in length. Streaks are not split into smaller streaks wrt
+		// cancelled proposals.
+		if(len(a.Proposals) >= 3) {
+			// update details with updated proposals array
+			strProps := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(a.Proposals)), ","), "[]")
+			s := strings.Split(a.Details, ":")
+			s[3] = strProps
+			a.Details = strings.Join(s, ":")
+			
+			_, err := db.Conn.Exec(db.Context, `
+				UPDATE user_achievements
+				SET proposals = $1, details = $2
+				WHERE id = $3
+			`, a.Proposals, a.Details, a.Id)
+		
+			if err != nil {
+				return err
+			}
+		} else {
+			_, err := db.Conn.Exec(db.Context, `DELETE FROM user_achievements WHERE id = $1`, a.Id)
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+
+	return nil
 }

--- a/backend/main/models/vote.go
+++ b/backend/main/models/vote.go
@@ -27,6 +27,7 @@ type Vote struct {
 	Cid                  *string                 `json:"cid"`
 	Message              string                  `json:"message"`
 	TransactionId        string                  `json:"transactionId"`
+	IsCancelled		 	 bool					 `json:"isCancelled"`
 }
 
 type VoteWithBalance struct {
@@ -57,6 +58,7 @@ type VotingStreak struct {
 
 const (
 	timestampExpiry = 60
+	defaultStreakLength = 3
 )
 
 const (
@@ -527,7 +529,7 @@ func addDefaultStreak(db *s.Database, addr string, communityId int, proposals []
 }
 
 func addOrUpdateStreak(db *s.Database, addr string, communityId int, proposals []uint64, details string) error {
-	v := new(Vote)
+	var id int
 	// If previous streak exists, then update with new streak details, or insert new streak
 	// e.g. If previous streak = 1,2,3 and current streak = 1,2,3,4 then update row with current streak details
 	previousStreakDetails := fmt.Sprintf("%s:%s:%d:%s", Streak, addr, communityId, strings.Trim(strings.Join(strings.Fields(fmt.Sprint(proposals[:len(proposals)-1])), ","), "[]"))
@@ -538,7 +540,7 @@ func addOrUpdateStreak(db *s.Database, addr string, communityId int, proposals [
 						DO UPDATE SET proposals = $4, details = $6
 						RETURNING id
 					`
-	return db.Conn.QueryRow(db.Context, sql, addr, Streak, communityId, proposals, previousStreakDetails, details).Scan(&v.ID)
+	return db.Conn.QueryRow(db.Context, sql, addr, Streak, communityId, proposals, previousStreakDetails, details).Scan(&id)
 }
 
 func checkErrorIgnoreNoRows(err error) bool {

--- a/backend/migrations/000033_alter_votes_table.down.sql
+++ b/backend/migrations/000033_alter_votes_table.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE votes DROP COLUMN is_cancelled;

--- a/backend/migrations/000033_alter_votes_table.up.sql
+++ b/backend/migrations/000033_alter_votes_table.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE votes ADD COLUMN is_cancelled BOOLEAN DEFAULT 'false';


### PR DESCRIPTION
**Ticket:** [CAS-393](https://linear.app/dappercollectives/issue/CAS-393/leaderboard-score-preserved-for-cancelled-proposals)

**Description:**

For the leaderboard, votes and achievements were being counted for cancelled proposals. Adds a helper function to clean up records in `votes` and `user_achievements` table when a proposal is cancelled.