### PR TITLE
CAS-395: Fix total users to match length of leaderboard or count

### DIFF
--- a/backend/main/models/community_users.go
+++ b/backend/main/models/community_users.go
@@ -147,7 +147,10 @@ func GetCommunityLeaderboard(
 		pageParams.Count,
 	)
 
-	totalUsers := getTotalUsersForCommunity(db, communityId)
+	totalUsers := len(leaderboardUsers)
+	if(totalUsers > pageParams.Count) {
+		totalUsers = pageParams.Count
+	}
 
 	payload.Users = leaderboardUsers
 	payload.CurrentUser = currentUser
@@ -274,13 +277,6 @@ func EnsureValidRole(userType string) bool {
 		}
 	}
 	return false
-}
-
-func getTotalUsersForCommunity(db *s.Database, communityId int) int {
-	var totalUsers int
-	countSql := `SELECT COUNT(*) FROM community_users WHERE community_id = $1`
-	_ = db.Conn.QueryRow(db.Context, countSql, communityId).Scan(&totalUsers)
-	return totalUsers
 }
 
 func getUserAchievements(db *s.Database, communityId int) (UserAchievements, error) {


### PR DESCRIPTION
**Ticket:** [CAS-395](https://linear.app/dappercollectives/issue/CAS-395/update-leaderboard-response-payload)

**Description:**

- Previously, totalUsers may have been returning an extra user in the count. Updated totalUsers to be the length of the leaderboard users, or count if leaderboard length is greater than count.
