### PR TITLE
cas 416 float Strategy: Voting Results not calculation correctly

### DIFF
--- a/backend/main/leaderboard_test.go
+++ b/backend/main/leaderboard_test.go
@@ -79,7 +79,7 @@ func TestGetLeaderboardWithSingleStreak(t *testing.T) {
 	communityId := otu.AddCommunities(1)[0]
 	streaks := []int{3, 4}
 	streakBonus := 1
-	expectedUsers := len(streaks)
+	expectedUsersNum := len(streaks)
 	expectedScoreA := streaks[0] + (1 * streakBonus)
 	expectedScoreB := streaks[1] + (1 * streakBonus)
 
@@ -101,7 +101,7 @@ func TestGetLeaderboardWithSingleStreak(t *testing.T) {
 	receivedScoreA := users[0].Score
 	receivedScoreB := users[1].Score
 
-	assert.Equal(t, expectedUsers, len(users))
+	assert.Equal(t, expectedUsersNum, len(users))
 	assert.Equal(t, expectedScoreA, receivedScoreA)
 	assert.Equal(t, expectedScoreB, receivedScoreB)
 }

--- a/backend/main/models/proposal.go
+++ b/backend/main/models/proposal.go
@@ -171,6 +171,13 @@ func (p *Proposal) UpdateProposal(db *s.Database) error {
 		return err
 	}
 
+	if *p.Status == "cancelled" {
+		err := handleCancelledProposal(db, p.ID)
+		if err != nil {
+			return err
+		}
+	}
+
 	err = p.GetProposalById(db)
 	return err
 }
@@ -290,4 +297,86 @@ func GetActiveStrategiesForCommunity(db *s.Database, communityId int) ([]string,
 	}
 
 	return strategies, nil
+}
+
+func handleCancelledProposal(db *s.Database, proposalId int) error {
+
+	// Delete All votes for cancelled proposal
+	_, err := db.Conn.Exec(db.Context, `
+		DELETE FROM votes WHERE proposal_id = $1
+	`, proposalId)
+
+	if err != nil {
+		return err
+	}
+
+	// Delete All non-streak achievements
+	_, err = db.Conn.Exec(db.Context, `
+		DELETE FROM user_achievements WHERE $1 = ANY (proposals) AND achievement_type != 'streak'
+	`, proposalId)
+
+	if err != nil {
+		return err
+	}
+
+	var achievements = []struct {
+		Id int64 `json:"id"`
+		Proposals []int64 `json:"proposals"`
+		Details string `json:"details"`
+	}{}
+
+	// handle streaks
+	err = pgxscan.Select(db.Context, db.Conn, &achievements, `
+		SELECT id, proposals, details FROM user_achievements WHERE $1 = ANY (proposals) AND achievement_type = 'streak'
+	`, proposalId)
+
+	if err != nil && err.Error() != pgx.ErrNoRows.Error() {
+		return err
+	}
+
+	for _, a := range achievements {
+		pId := int64(proposalId)
+	
+	  	// Find index of proposal id being cancelled
+		index := -1
+		for i, id := range a.Proposals {
+			if id == pId {
+				index = i
+				break
+			}
+		}
+
+		// Remove proposalId from array
+		copy(a.Proposals[index:], a.Proposals[index+1:])
+		a.Proposals = a.Proposals[:len(a.Proposals)-1]
+
+		// NOTE: If cancelled proposal is in the middle of a streak greater than 3, the user will maintain
+		// their streak, but it will be one less in length. Streaks are not split into smaller streaks wrt
+		// cancelled proposals.
+		if(len(a.Proposals) >= 3) {
+			// update details with updated proposals array
+			strProps := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(a.Proposals)), ","), "[]")
+			s := strings.Split(a.Details, ":")
+			s[3] = strProps
+			a.Details = strings.Join(s, ":")
+			
+			_, err := db.Conn.Exec(db.Context, `
+				UPDATE user_achievements
+				SET proposals = $1, details = $2
+				WHERE id = $3
+			`, a.Proposals, a.Details, a.Id)
+		
+			if err != nil {
+				return err
+			}
+		} else {
+			_, err := db.Conn.Exec(db.Context, `DELETE FROM user_achievements WHERE id = $1`, a.Id)
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+
+	return nil
 }

--- a/backend/main/strategies/balance_of_nfts.go
+++ b/backend/main/strategies/balance_of_nfts.go
@@ -83,12 +83,11 @@ func (b *BalanceOfNfts) TallyVotes(
 ) (models.ProposalResults, error) {
 
 	for _, vote := range votes {
-
 		if len(vote.NFTs) != 0 {
 			var allowedBalance float64
 
 			if proposal.Max_weight != nil {
-				allowedBalance = proposal.EnforceMaxWeight(float64(*vote.PrimaryAccountBalance))
+				allowedBalance = proposal.EnforceMaxWeight(float64(len(vote.NFTs)))
 			} else {
 				allowedBalance = float64(len(vote.NFTs))
 			}

--- a/backend/main/strategies/float_nfts.go
+++ b/backend/main/strategies/float_nfts.go
@@ -93,12 +93,11 @@ func (s *FloatNFTs) TallyVotes(
 ) (models.ProposalResults, error) {
 
 	for _, vote := range votes {
-
 		if len(vote.NFTs) != 0 {
 			var allowedBalance float64
 
 			if proposal.Max_weight != nil {
-				allowedBalance = proposal.EnforceMaxWeight(float64(*vote.PrimaryAccountBalance))
+				allowedBalance = proposal.EnforceMaxWeight(float64(len(vote.NFTs)))
 			} else {
 				allowedBalance = float64(len(vote.NFTs))
 			}

--- a/backend/main/strategies/token_weighted_default.go
+++ b/backend/main/strategies/token_weighted_default.go
@@ -7,7 +7,6 @@ import (
 	"github.com/DapperCollectives/CAST/backend/main/models"
 	s "github.com/DapperCollectives/CAST/backend/main/shared"
 	shared "github.com/DapperCollectives/CAST/backend/main/shared"
-	"github.com/jackc/pgx/v4"
 	"github.com/rs/zerolog/log"
 )
 
@@ -24,11 +23,6 @@ func (s *TokenWeightedDefault) FetchBalance(
 
 	var c models.Community
 	if err := c.GetCommunityByProposalId(s.DB, b.Proposal_id); err != nil {
-		return nil, err
-	}
-
-	if err := b.GetBalanceByAddressAndBlockHeight(s.DB); err != nil && err.Error() != pgx.ErrNoRows.Error() {
-		log.Error().Err(err).Msg("Error fetching balance from database.")
 		return nil, err
 	}
 

--- a/backend/main/test_utils/leaderboard_utils.go
+++ b/backend/main/test_utils/leaderboard_utils.go
@@ -1,6 +1,8 @@
 package test_utils
 
-import "strconv"
+import (
+	"strconv"
+)
 
 func (otu *OverflowTestUtils) GenerateVotes(communityId int, numProposals int, numUsers int) {
 	if numProposals == 0 {


### PR DESCRIPTION
• fixes a typo in NFT strategies with `EnforceMaxWeight` where `PrimaryAccountBalance` was being used not `len(vote.NFTs)`