### PR TITLE
hotfix added initialization if not in local dev

### DIFF
--- a/backend/main/shared/structs.go
+++ b/backend/main/shared/structs.go
@@ -96,6 +96,10 @@ func (b *FTBalanceResponse) NewFTBalance() {
 		b.PrimaryAccountBalance = 11100000
 		b.SecondaryAccountBalance = 12300000
 		b.StakingBalance = 13500000
+	} else {
+		b.PrimaryAccountBalance = 0
+		b.SecondaryAccountBalance = 0
+		b.StakingBalance = 0
 	}
 }
 


### PR DESCRIPTION
the fields of `ftBalance` Struct, which gets updated from the snapshotter, was not being initialized in staging / prod. This is a fix that adds 0 vals, these vals get overridden when the snapshotter returns. 

If these fields are left uninitialized, the function `GetAddressBalanceAtBlockHeight` cannot update `ftBalance` by reference. 