### PR TITLE
CAS-427: Fix Proposal restriction using NFT Contract

### DIFF
--- a/backend/main/models/community.go
+++ b/backend/main/models/community.go
@@ -37,6 +37,7 @@ type Community struct {
 
 	Contract_name *string  `json:"contractName,omitempty"`
 	Contract_addr *string  `json:"contractAddr,omitempty"`
+	Contract_type *string  `json:"contractType,omitempty"`
 	Public_path   *string  `json:"publicPath,omitempty"`
 	Threshold     *float64 `json:"threshold,omitempty"`
 
@@ -75,6 +76,7 @@ type UpdateCommunityRequestPayload struct {
 	//TODO dup fields in Community struct, make sub struct for both to use
 	Contract_name *string  `json:"contractName,omitempty"`
 	Contract_addr *string  `json:"contractAddr,omitempty"`
+	Contract_type *string  `json:"contractType,omitempty"`
 	Public_path   *string  `json:"publicPath,omitempty"`
 	Threshold     *float64 `json:"threshold,omitempty"`
 
@@ -185,12 +187,12 @@ func (c *Community) CreateCommunity(db *s.Database) error {
 	err := db.Conn.QueryRow(db.Context,
 		`
 	INSERT INTO communities(
-		name, category, logo, slug, strategies, strategy, banner_img_url, website_url, twitter_url, github_url, discord_url, instagram_url, terms_and_conditions_url, proposal_validation, proposal_threshold, body, cid, creator_addr, contract_name, contract_addr, public_path, threshold, only_authors_to_submit)
+		name, category, logo, slug, strategies, strategy, banner_img_url, website_url, twitter_url, github_url, discord_url, instagram_url, terms_and_conditions_url, proposal_validation, proposal_threshold, body, cid, creator_addr, contract_name, contract_addr, public_path, threshold, only_authors_to_submit, contract_type)
 	VALUES(
-		$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23
+		$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24
 	)
 	RETURNING id, created_at
-	`, c.Name, c.Category, c.Logo, c.Slug, c.Strategies, c.Strategy, c.Banner_img_url, c.Website_url, c.Twitter_url, c.Github_url, c.Discord_url, c.Instagram_url, c.Terms_and_conditions_url, c.Proposal_validation, c.Proposal_threshold, c.Body, c.Cid, c.Creator_addr, c.Contract_name, c.Contract_addr, c.Public_path, c.Threshold, c.Only_authors_to_submit).Scan(&c.ID, &c.Created_at)
+	`, c.Name, c.Category, c.Logo, c.Slug, c.Strategies, c.Strategy, c.Banner_img_url, c.Website_url, c.Twitter_url, c.Github_url, c.Discord_url, c.Instagram_url, c.Terms_and_conditions_url, c.Proposal_validation, c.Proposal_threshold, c.Body, c.Cid, c.Creator_addr, c.Contract_name, c.Contract_addr, c.Public_path, c.Threshold, c.Only_authors_to_submit, c.Contract_type).Scan(&c.ID, &c.Created_at)
 	return err
 }
 

--- a/backend/main/server/controllers.go
+++ b/backend/main/server/controllers.go
@@ -210,7 +210,7 @@ func (a *App) createProposal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	proposal, httpStatus, err := helpers.createProposal(communityId, p)
+	proposal, httpStatus, err := helpers.createProposal(p)
 	if err != nil {
 		respondWithError(w, httpStatus, err.Error())
 		return
@@ -320,7 +320,7 @@ func (a *App) createCommunity(w http.ResponseWriter, r *http.Request) {
 		respondWithError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-
+	
 	//Validate Contract Thresholds
 	err = validateContractThreshold(*payload.Strategies)
 	if err != nil {

--- a/backend/migrations/000034_alter_communities_table.down.sql
+++ b/backend/migrations/000034_alter_communities_table.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE communities DROP COLUMN contract_type;

--- a/backend/migrations/000034_alter_communities_table.up.sql
+++ b/backend/migrations/000034_alter_communities_table.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE communities ADD COLUMN contract_type VARCHAR(5);

--- a/frontend/packages/client/src/components/Community/CommunityEditorProfile/ProfileForm.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorProfile/ProfileForm.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { Form, WrapperResponsive } from 'components';

--- a/frontend/packages/client/src/components/Community/ProposalThresholdEditor/FormConfig.js
+++ b/frontend/packages/client/src/components/Community/ProposalThresholdEditor/FormConfig.js
@@ -47,6 +47,16 @@ const Schema = (isValidFlowAddress) =>
         is: false,
         then: yup.string().required('Please enter a contract name'),
       }),
+    contractType: yup
+      .string()
+      .trim()
+      .makeOtherFieldsRequired(
+        'Please select a contract type if other fields are not empty'
+      )
+      .when('onlyAuthorsToSubmitProposals', {
+        is: false,
+        then: yup.string().required('Please enter a contract type'),
+      }),
     storagePath: yup
       .string()
       .trim()

--- a/frontend/packages/client/src/components/Community/ProposalThresholdEditor/ProposalThresholdEditor.js
+++ b/frontend/packages/client/src/components/Community/ProposalThresholdEditor/ProposalThresholdEditor.js
@@ -15,6 +15,7 @@ const { flowAddress } = networkConfig;
 const defaultValues = {
   contractAddress: flowAddress.contractAddr,
   contractName: flowAddress.contractName,
+  contractType: 'ft',
   storagePath: flowAddress.storagePath,
   proposalThreshold: '0',
 };
@@ -22,6 +23,7 @@ const defaultValues = {
 const checkFieldValues = ({
   contractAddress,
   contractName,
+  contractType,
   storagePath,
   proposalThreshold,
   onlyAuthorsToSubmitProposals,
@@ -31,6 +33,7 @@ const checkFieldValues = ({
     isEqual(defaultValues, {
       contractAddress,
       contractName,
+      contractType,
       storagePath,
       proposalThreshold,
     })
@@ -40,6 +43,7 @@ const checkFieldValues = ({
 const checkIfNeedsDefaultValues = ({
   contractAddress: contractAddr,
   contractName,
+  contractType,
   storagePath: publicPath,
   proposalThreshold,
   onlyAuthorsToSubmitProposals: onlyAuthorsToSubmit,
@@ -53,6 +57,7 @@ const checkIfNeedsDefaultValues = ({
     return {
       contractAddr: defaultValues.contractAddress,
       contractName: defaultValues.contractName,
+      contractType: defaultValues.contractType,
       publicPath: defaultValues.storagePath,
       proposalThreshold: defaultValues.proposalThreshold,
       onlyAuthorsToSubmit,
@@ -61,6 +66,7 @@ const checkIfNeedsDefaultValues = ({
   return {
     contractAddr,
     contractName,
+    contractType,
     publicPath,
     proposalThreshold,
     onlyAuthorsToSubmit,
@@ -71,6 +77,7 @@ export default function ProposalThresholdEditor({
   updateCommunity = () => {},
   contractAddress,
   contractName,
+  contractType,
   storagePath,
   proposalThreshold,
   onlyAuthorsToSubmitProposals,
@@ -84,12 +91,13 @@ export default function ProposalThresholdEditor({
   const useEmptyFields = checkFieldValues({
     contractAddress,
     contractName,
+    contractType,
     storagePath,
     proposalThreshold,
     onlyAuthorsToSubmitProposals,
   });
 
-  const { register, handleSubmit, formState, reset } = useForm({
+  const { control, register, handleSubmit, formState, reset } = useForm({
     resolver: yupResolver(Schema(isValidFlowAddress)),
     defaultValues: {
       ...(useEmptyFields
@@ -97,9 +105,16 @@ export default function ProposalThresholdEditor({
             proposalThreshold: '',
             contractAddress: '',
             contractName: '',
+            contractType: '',
             storagePath: '',
           }
-        : { proposalThreshold, contractAddress, contractName, storagePath }),
+        : {
+            proposalThreshold,
+            contractAddress,
+            contractName,
+            contractType,
+            storagePath,
+          }),
       onlyAuthorsToSubmitProposals,
     },
   });
@@ -122,6 +137,7 @@ export default function ProposalThresholdEditor({
       handleSubmit={handleSubmit(onSubmit)}
       errors={errors}
       register={register}
+      control={control}
       isSubmitting={isSubmitting}
       submitComponent={
         <div className="columns mb-5">

--- a/frontend/packages/client/src/components/Community/ProposalThresholdEditor/ThresholdForm.js
+++ b/frontend/packages/client/src/components/Community/ProposalThresholdEditor/ThresholdForm.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { WrapperResponsive } from 'components';
 import Checkbox from 'components/common/Checkbox';
+import Dropdown from 'components/common/Dropdown';
 import Form from 'components/common/Form';
 import Input from 'components/common/Input';
 
@@ -10,6 +11,7 @@ export default function ThresholdForm({
   submitComponent = null,
   errors = [],
   register = () => {},
+  control = () => {},
   isSubmitting = false,
 } = {}) {
   return (
@@ -32,6 +34,23 @@ export default function ThresholdForm({
             </p>
           </div>
         </div>
+        <Dropdown
+          label="Contract Type"
+          name="contractType"
+          margin="mt-4"
+          options={[
+            {
+              label: 'NFT',
+              value: 'nft',
+            },
+            {
+              label: 'Fungible Token',
+              value: 'ft',
+            },
+          ]}
+          disabled={isSubmitting}
+          control={control}
+        />
         <Input
           placeholder="Contract Address"
           register={register}

--- a/frontend/packages/client/src/components/CommunityCreate/StepThree.js
+++ b/frontend/packages/client/src/components/CommunityCreate/StepThree.js
@@ -17,18 +17,20 @@ export default function StepThree({
     proposalThreshold = '',
     contractAddress = '',
     contractName = '',
+    contractType = '',
     storagePath = '',
     onlyAuthorsToSubmitProposals = false,
   } = stepData;
 
   const { isValidFlowAddress } = useWebContext();
 
-  const { register, handleSubmit, formState } = useForm({
+  const { control, register, handleSubmit, formState } = useForm({
     resolver: yupResolver(Schema(isValidFlowAddress)),
     defaultValues: {
       proposalThreshold,
       contractAddress,
       contractName,
+      contractType,
       storagePath,
       onlyAuthorsToSubmitProposals,
     },
@@ -45,6 +47,7 @@ export default function StepThree({
       handleSubmit={handleSubmit(onSubmit)}
       errors={errors}
       register={register}
+      control={control}
       isSubmitting={isSubmitting}
       submitComponent={
         <div className="columns mb-5">

--- a/frontend/packages/client/src/hooks/useCommunity.js
+++ b/frontend/packages/client/src/hooks/useCommunity.js
@@ -99,8 +99,9 @@ export default function useCommunity({
           websiteUrl,
           logo,
           banner,
-          contractAdrress: contractAddr,
+          contractAddress: contractAddr,
           contractName: contractN,
+          contractType,
           storagePath: storageP,
           proposalThreshold,
           onlyAuthorsToSubmitProposals,
@@ -152,6 +153,7 @@ export default function useCommunity({
               flowAddress.contractAddr
             ),
             contractName: setDefaultValue(contractN, flowAddress.contractName),
+            contractType,
             publicPath: setDefaultValue(storageP, flowAddress.storagePath),
             proposalThreshold: setDefaultValue(proposalThreshold, '0'),
             strategies,
@@ -160,6 +162,7 @@ export default function useCommunity({
             compositeSignatures,
           }),
         };
+
         const response = await fetch(url, fetchOptions);
         const json = await checkResponse(response);
         dispatch({ type: 'SUCCESS', payload: { data: [json] } });


### PR DESCRIPTION
**Description:**

- Adds a Contract Type field to the Community Proposal Page. This will allow the backend to choose the right cadence script when validating proposal creation
- Adds `Contract_type` to the `communities` table to track the contract type for proposal creation.
- If a user attempt to create a proposal without matching the specified threshold for proposal creation, they will get a 403 error.

![Screen Shot 2022-08-19 at 1 53 02 PM](https://user-images.githubusercontent.com/22734700/185705494-7aa4850e-8365-46cd-b73f-f17598b23764.png)
e

NOTE: This fix should also address: [CAS-435](https://linear.app/dappercollectives/issue/CAS-435)