### PR TITLE
CAS-405 - Fix to open file explorer when uploading images

### DIFF
--- a/frontend/packages/client/src/components/Community/CommunityEditorProfile/ProfileForm.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorProfile/ProfileForm.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useErrorHandlerContext } from 'contexts/ErrorHandler';
 import { Form, WrapperResponsive } from 'components';
@@ -82,6 +82,7 @@ export default function ProfileForm({
       onDrop: onDrop('community_image', 'logo', MAX_AVATAR_FILE_SIZE, 150),
       maxFiles: 1,
       accept: 'image/jpeg,image/png',
+      useFsAccessApi: false,
     });
 
   const {
@@ -91,6 +92,7 @@ export default function ProfileForm({
     onDrop: onDrop('community_banner', 'banner', MAX_FILE_SIZE, 1200),
     maxFiles: 1,
     accept: 'image/jpeg,image/png',
+    useFsAccessApi: false,
   });
 
   const imageDropClasses = classnames(

--- a/frontend/packages/client/src/components/ProposalCreate/StepOne/ImageChoiceUploader.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepOne/ImageChoiceUploader.js
@@ -177,6 +177,7 @@ export default function ImageChoiceUploader({
     onDrop,
     maxFiles: 1,
     accept: 'image/jpeg,image/png,image/gif',
+    useFsAccessApi: false,
   });
 
   return (

--- a/frontend/packages/client/src/components/UploadImageModal.js
+++ b/frontend/packages/client/src/components/UploadImageModal.js
@@ -204,6 +204,7 @@ export default function UploadImageModal({
     onDrop,
     maxFiles: maxImageFiles,
     accept: 'image/jpeg,image/png,image/gif',
+    useFsAccessApi: false,
   });
 
   const onUploadStared = useCallback(


### PR DESCRIPTION
Based on this [issue](https://github.com/react-dropzone/react-dropzone/issues/1222) opened on the [react-dropzone](https://react-dropzone.js.org/) GitHub [repo](https://github.com/react-dropzone/)  setting `useFsAccessApi` to `false` makes the file explorer to open when clicking on the button 