### PR TITLE
cas 425 `make float` so that we can test float on local dev

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -29,7 +29,7 @@ float:
 	flow accounts add-contract GrantedAccountAccess ./main/cadence/float/GrantedAccountAccess.cdc && \
 	flow accounts add-contract FLOAT ./main/cadence/float/FLOAT.cdc && \
 	flow accounts add-contract FLOATVerifiers ./main/cadence/float/FLOATVerifiers.cdc && \
-	flow transactions send ./main/cadence/float/transactions/create_group.cdc "cast-group""image" "local-dev-group" && \
+	flow transactions send ./main/cadence/float/transactions/create_group.cdc "cast-group" "image" "local-dev-group" && \
 	flow transactions send ./main/cadence/float/transactions/create_event.cdc 0xf8d6e0586b0a20c7 true "local-dev" "for emulator smoke testing" "image" "www.url.com" true false 10000.00 86400.00 false "secret" false 100 '["cast-group"]' false 0.0 false 0.0
 
 	

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -25,9 +25,14 @@ nft:
 		flow transactions send ./main/cadence/transactions/mint_nft.cdc 0xf8d6e0586b0a20c7 "dev_nft" "don't try at home" "thumnbail goes here" '[0.8]' '["royalties"]' '[0xf8d6e0586b0a20c7]' 
 
 float: 
+	make nft && \
 	flow accounts add-contract GrantedAccountAccess ./main/cadence/float/GrantedAccountAccess.cdc && \
 	flow accounts add-contract FLOAT ./main/cadence/float/FLOAT.cdc && \
-	flow accounts add-contract FLOATVerifiers ./main/cadence/float/FLOATVerifiers.cdc
+	flow accounts add-contract FLOATVerifiers ./main/cadence/float/FLOATVerifiers.cdc && \
+	flow transactions send ./main/cadence/float/transactions/create_group.cdc "cast-group""image" "local-dev-group" && \
+	flow transactions send ./main/cadence/float/transactions/create_event.cdc 0xf8d6e0586b0a20c7 true "local-dev" "for emulator smoke testing" "image" "www.url.com" true false 10000.00 86400.00 false "secret" false 100 '["cast-group"]' false 0.0 false 0.0
+
+	
 
 macdev:
 	APP_ENV=DEV make macrun

--- a/backend/main/cadence/float/transactions/create_group.cdc
+++ b/backend/main/cadence/float/transactions/create_group.cdc
@@ -1,6 +1,7 @@
 import FLOAT from 0xf8d6e0586b0a20c7
 import FLOATVerifiers from 0xf8d6e0586b0a20c7
 import NonFungibleToken from 0xf8d6e0586b0a20c7
+import MetadataViews from 0xf8d6e0586b0a20c7
 import GrantedAccountAccess from 0xf8d6e0586b0a20c7
 
 transaction(groupName: String, image: String, description: String) {

--- a/backend/main/cadence/float/transactions/create_group.cdc
+++ b/backend/main/cadence/float/transactions/create_group.cdc
@@ -1,7 +1,7 @@
-import FLOAT from 
-import NonFungibleToken from 
-import MetadataViews from 
-import GrantedAccountAccess from 
+import FLOAT from 0xf8d6e0586b0a20c7
+import FLOATVerifiers from 0xf8d6e0586b0a20c7
+import NonFungibleToken from 0xf8d6e0586b0a20c7
+import GrantedAccountAccess from 0xf8d6e0586b0a20c7
 
 transaction(groupName: String, image: String, description: String) {
 
@@ -37,4 +37,6 @@ transaction(groupName: String, image: String, description: String) {
   execute {
     self.FLOATEvents.createGroup(groupName: groupName, image: image, description: description)
     log("Created a new Group.")
+  }
+
   }


### PR DESCRIPTION
This PR adds a new make command `make float` this adds one FLOAT nft into the admin local emulator wallet address `0xf8d6e0586b0a20c7`

If we need to test float functionality locally in the emulator its now possible by running this command. 

N.B if you've already ran `make nft` you'll have to quit the emulator then run `make float` as both commands deploy some of the same dependancy contracts to the same address.  `make float` internally calls `make nft`
