### PR TITLE
hotfix staging - added port flag definition

### DIFF
--- a/backend/main/server/app.go
+++ b/backend/main/server/app.go
@@ -117,6 +117,7 @@ func (a *App) Initialize() {
 
 	// when running "make proposals" sets db to dev not test
 	arg := flag.String("db", "", "database type")
+	flag.Int("port", 5001, "port")
 	flag.Int("amount", 4, "Amount of proposals to create")
 
 	flag.Parse()


### PR DESCRIPTION
*adds port flag definition in `Initialize`

after other flags were defined, in staging we were seeing the error
```
11:50PM INF Log level: DEBUG for APP_ENV=PRODUCTION
flag provided but not defined: -port
Usage of /flow-voting-tool/flow-voting-tool-server:
  -amount int
    	Amount of proposals to create (default 4)
  -db string
    	database type
flag provided but not defined: -port
```
The port flag is not used in the Makefile but it is used inside out Dockerfile. Hoping this will fix it!

**General Note**

How `flat.Int()` works : 
```
func flag.Int(name string, value int, usage string) *int
Int defines an int flag with specified name, default value, and usage string.
The return value is the address of an int variable that stores the value of the flag.
flag.Int on pkg.go.dev
```
Flags need to be defined before calling `flag.Parse()`