### PR TITLE
adds in contract replace code for topshot Addr

### DIFF
--- a/backend/flow.json
+++ b/backend/flow.json
@@ -43,6 +43,14 @@
 				"testnet": "0x631e88ae7f1d7c20",
 				"mainnet": "0x1d7e57aa55817448"
 			}
+		},
+		"TopShot": {
+			"source": "./main/cadence/nba/Topshot.cdc",
+			"aliases": {
+				"emulator": "0xf8d6e0586b0a20c7",
+				"testnet": "0x877931736ee77cff",
+				"mainnet": "0x0b2a3299cc857e29"
+			}
 		}
 	},
 	"networks": {

--- a/backend/main/cadence/scripts/custom/get_nba_topshot.cdc
+++ b/backend/main/cadence/scripts/custom/get_nba_topshot.cdc
@@ -1,5 +1,5 @@
-import TopShot from 0xf8d6e0586b0a20c7
-import MetadataViews from 0xf8d6e0586b0a20c7
+import TopShot from "TOPSHOT_ADDRESS" 
+import MetadataViews from "METADATA_VIEWS_ADDRESS"
 
 pub fun main(address: Address): [UInt64] {
     let account = getAccount(address)

--- a/backend/main/shared/flow.go
+++ b/backend/main/shared/flow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -55,6 +56,7 @@ var (
 	placeholderNonFungibleTokenAddr = regexp.MustCompile(`"[^"\s]*NON_FUNGIBLE_TOKEN_ADDRESS"`)
 	placeholderMetadataViewsAddr    = regexp.MustCompile(`"[^"\s]*METADATA_VIEWS_ADDRESS"`)
 	placeholderCollectionPublicPath = regexp.MustCompile(`"[^"\s]*COLLECTION_PUBLIC_PATH"`)
+	placeholderTopshotAddr          = regexp.MustCompile(`"[^"\s]*TOPSHOT_ADDRESS"`)
 )
 
 func NewFlowClient(flowEnv string) *FlowAdapter {
@@ -418,11 +420,13 @@ func (fa *FlowAdapter) ReplaceContractPlaceholders(code string, c *Contract, isF
 		fungibleTokenAddr    string
 		nonFungibleTokenAddr string
 		metadataViewsAddr    string
+		topshotAddr          string
 	)
 
 	nonFungibleTokenAddr = fa.Config.Contracts["NonFungibleToken"].Aliases[os.Getenv("FLOW_ENV")]
 	fungibleTokenAddr = fa.Config.Contracts["FungibleToken"].Aliases[os.Getenv("FLOW_ENV")]
 	metadataViewsAddr = fa.Config.Contracts["MetadataViews"].Aliases[os.Getenv("FLOW_ENV")]
+	topshotAddr = fa.Config.Contracts["TopShot"].Aliases[os.Getenv("FLOW_ENV")]
 
 	if isFungible {
 		code = placeholderFungibleTokenAddr.ReplaceAllString(code, fungibleTokenAddr)
@@ -434,6 +438,9 @@ func (fa *FlowAdapter) ReplaceContractPlaceholders(code string, c *Contract, isF
 	code = placeholderMetadataViewsAddr.ReplaceAllString(code, metadataViewsAddr)
 	code = placeholderTokenName.ReplaceAllString(code, *c.Name)
 	code = placeholderTokenAddr.ReplaceAllString(code, *c.Addr)
+	code = placeholderTopshotAddr.ReplaceAllString(code, topshotAddr)
+
+	fmt.Printf("code: %s \n", code)
 
 	return []byte(code)
 }


### PR DESCRIPTION
•adds in contract address replace code, all the addresses for each environment are in the `flow.json`. tested locally and the addresses are being replaced correctly. 