### PR TITLE
allow unconnected user to vote, then prompt wallet connect

### DIFF
--- a/frontend/packages/client/src/components/Proposal/VoteOptions.js
+++ b/frontend/packages/client/src/components/Proposal/VoteOptions.js
@@ -241,6 +241,7 @@ const VoteOptions = ({
   optionChosen,
   castVote,
   onConfirmVote,
+  loggedIn,
   addr,
   readOnly = false,
 }) => {
@@ -272,8 +273,7 @@ const VoteOptions = ({
       (voteObj) => String(proposal.id) !== Object.keys(voteObj)[0]
     );
 
-  const canVote = addr && isActive && hasntVoted;
-
+  const canVote = isActive && (hasntVoted || !loggedIn);
   const voteClasses = `vote-options border-light rounded-sm mb-6 ${
     !canVote && 'is-disabled'
   } ${!hasntVoted && 'is-voted'}`;

--- a/frontend/packages/client/src/pages/Proposal.js
+++ b/frontend/packages/client/src/pages/Proposal.js
@@ -77,7 +77,8 @@ export default function ProposalPage() {
 
   const modalContext = useModalContext();
 
-  const { user, injectedProvider, setWebContextConfig } = useWebContext();
+  const { user, injectedProvider, setWebContextConfig, openWalletModal } =
+    useWebContext();
 
   // setting this manually for users that do not have a ledger device
   useEffect(() => {
@@ -149,7 +150,11 @@ export default function ProposalPage() {
   };
 
   const onConfirmVote = () => {
-    setConfirmingVote(true);
+    if (user.loggedIn) {
+      setConfirmingVote(true);
+    } else {
+      openWalletModal();
+    }
   };
 
   const onCancelVote = () => {
@@ -543,6 +548,7 @@ export default function ProposalPage() {
                 <VoteOptions
                   labelType="desktop"
                   readOnly={isClosed}
+                  loggedIn={user?.loggedIn}
                   addr={user?.addr}
                   proposal={proposal}
                   onOptionSelect={onOptionSelect}


### PR DESCRIPTION
previously we didnt let people interact with the VoteOptions component if they werent logged in, now we will but prompt them to connect before they can actually cast their vote