### PR TITLE
update global styles / classes

### DIFF
--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -1,23 +1,17 @@
-@import url('https://fonts.googleapis.com/css?family=Arimo:regular,bold,italic&subset=latin,latin-ext')
-@import url('https://fonts.googleapis.com/css?family=Roboto+Mono:regular,bold,italic&subset=latin,latin-ext')
+@import url('https://fonts.googleapis.com/css?family=DM+Sans:regular,bold,italic&subset=latin,latin-ext')
 @charset "utf-8"
 
 // Set brand colors
-$green: #0E5B20
-$light-green: #00EF8B
-$red: #B20D0D
-$error-red: #B20D0D
+$success: #3EAE4F
+$danger: #F54339
 $yellow: #FBD84D
 $orange: #F4AF4A
-$light-gray: #DCDCDC
-$lighter-dark-grey: #757575
+$light-grey: #DCDCDC
+$grey: #636363
 
 // Update Bulma's global variables
-$family-primary: "Arimo"
-$family-secondary: "Arimo"
-$family-code: "Roboto Mono"
-$family-monospace: "Roboto Mono"
-$title-family: $family-secondary
+$family-sans-serif: "DM Sans"
+$family-monospace: "DM Sans"
 $body-color: black
 $body-background-color: white
 $primary: $yellow
@@ -34,7 +28,7 @@ $button-border-width: 1px
 $title-size: 2.5rem
 $progress-bar-background-color: $yellow
 $input-color: black
-$white-ter: #F2F2F2
+$white-ter: #F9F9F9
 $border-color-light: #DBDBDB
 
 // Import only what you need from Bulma
@@ -148,10 +142,10 @@ code
 	border-radius: 50%
 .border-light
 	border: 1px solid $grey-lighter
-.border-lighter-dark-grey
-	border: 1px solid $lighter-dark-grey
+.border-grey
+	border: 1px solid $grey
 .border-dashed-dark
-	border: 2px dashed $lighter-dark-grey
+	border: 2px dashed $grey
 .flex-1
 	flex: 1 0 0
 .flex-2
@@ -355,10 +349,6 @@ hr
 	font-size: 0.88rem !important
 .smaller-text
 	font-size: 0.75rem !important
-.has-text-back
-	color: #000000 !important
-.has-text-red
-	color: $red
 
 @import './components/StepByStep/StepByStep.sass'
 
@@ -603,12 +593,12 @@ span[data-tooltip]
 .table
 	border-radius: 8px
 	border-style: hidden
-	box-shadow: 0 0 0 1px $light-gray
+	box-shadow: 0 0 0 1px $light-grey
 	td
 		vertical-align: middle !important
 		height: 64px !important
-	.has-background-light-gray
-		background-color: $light-gray
+	.has-background-light-grey
+		background-color: $light-grey
 	thead th
 		border-width: 0 0 1px !important
 	.index-cell
@@ -672,7 +662,7 @@ span[data-tooltip]
 .form-error-input-icon
 	padding-right: 4.5rem !important
 .form-error-input-border
-	border-color: $error-red  !important
+	border-color: $danger  !important
 
 .form-checkbox
 	-webkit-appearance: none

--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -681,7 +681,6 @@ span[data-tooltip]
 .image-caption-draft-js
 	.public-DraftStyleDefault-block.public-DraftStyleDefault-ltr
 		margin: 0px !important
-		font-family: 'Arimo'
 		font-style: normal
 		font-weight: 400
 		font-size: 12px

--- a/frontend/packages/client/src/components/Community/CommunityEditorDetails/FormFields.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorDetails/FormFields.js
@@ -78,7 +78,7 @@ export default function Form({
               {errorInField && (
                 <FadeIn>
                   <div className="pl-1 mt-2">
-                    <p className="smaller-text has-text-red">
+                    <p className="smaller-text has-text-danger">
                       {errorInField.message}
                     </p>
                   </div>

--- a/frontend/packages/client/src/components/Community/CommunityEditorLinks/FormFields.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorLinks/FormFields.js
@@ -38,7 +38,7 @@ export default function Form({
           {errors[formField.fieldName] && (
             <FadeIn>
               <div className="pl-1 mt-2">
-                <p className="smaller-text has-text-red">
+                <p className="smaller-text has-text-danger">
                   {errors[formField.fieldName]?.message}
                 </p>
               </div>

--- a/frontend/packages/client/src/components/Community/CommunityPropsAndVoting.js
+++ b/frontend/packages/client/src/components/Community/CommunityPropsAndVoting.js
@@ -59,7 +59,7 @@ export default function CommunityProposalsAndVoting({
                 <ul>
                   {errorMessages.map((type, index) => (
                     <li key={`error-${index}`}>
-                      <p className="smaller-text mt-2 has-text-red">
+                      <p className="smaller-text mt-2 has-text-danger">
                         - {kebabToString(type)}
                       </p>
                     </li>

--- a/frontend/packages/client/src/components/Community/StrategySelectorForm.js
+++ b/frontend/packages/client/src/components/Community/StrategySelectorForm.js
@@ -90,7 +90,7 @@ export default function StrategySelectorForm({
               <div className="is-flex is-align-items-center is-justify-content-center">
                 <ul>
                   <li>
-                    <p className="smaller-text mt-2 has-text-red">
+                    <p className="smaller-text mt-2 has-text-danger">
                       - {getStrategyName(allVotingStrategies, strategy)}
                     </p>
                   </li>

--- a/frontend/packages/client/src/components/ProposalCreate/StepOne/ImageChoiceUploader.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepOne/ImageChoiceUploader.js
@@ -47,7 +47,7 @@ const UploadArea = ({ getRootProps, getInputProps, errorMessage }) => {
         </div>
       </div>
       {errorMessage && (
-        <p className="small-text pt-2 has-text-red">* {errorMessage}</p>
+        <p className="small-text pt-2 has-text-danger">* {errorMessage}</p>
       )}
     </>
   );
@@ -190,7 +190,7 @@ export default function ImageChoiceUploader({
           {errorParam?.choiceImgUrl?.message && (
             <FadeIn>
               <div className="pl-1 pt-2">
-                <p className="smaller-text has-text-red">
+                <p className="smaller-text has-text-danger">
                   {errorParam.choiceImgUrl.message}
                 </p>
               </div>
@@ -265,7 +265,7 @@ export default function ImageChoiceUploader({
       {errorParam?.value?.message && (
         <FadeIn>
           <div className="pl-1 pt-2">
-            <p className="smaller-text has-text-red">
+            <p className="smaller-text has-text-danger">
               {errorParam.value.message}
             </p>
           </div>

--- a/frontend/packages/client/src/components/ProposalCreate/StepOne/ImageChoices.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepOne/ImageChoices.js
@@ -32,7 +32,7 @@ const ImageChoices = ({ error, control } = {}) => {
     <>
       <div className="columns flex-1">
         <div className="column pt-4">
-          <p className="smaller-text has-text-gray">
+          <p className="smaller-text has-text-grey">
             Accepted files: PNG, JPG, GIF
           </p>
         </div>

--- a/frontend/packages/client/src/components/ProposalCreate/StepOne/TextBasedChoices.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepOne/TextBasedChoices.js
@@ -79,7 +79,7 @@ const TextBasedChoices = ({
             {errorInField && (
               <FadeIn>
                 <div className="pl-1 mt-2 mb-4">
-                  <p className="smaller-text has-text-red">
+                  <p className="smaller-text has-text-danger">
                     {errorInField.message}
                   </p>
                 </div>
@@ -91,7 +91,7 @@ const TextBasedChoices = ({
       {error?.message && (
         <FadeIn>
           <div className="pl-1">
-            <p className="smaller-text has-text-red">{error.message}</p>
+            <p className="smaller-text has-text-danger">{error.message}</p>
           </div>
         </FadeIn>
       )}

--- a/frontend/packages/client/src/components/ProposalCreate/StepTwo/StepTwo.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepTwo/StepTwo.js
@@ -160,7 +160,7 @@ const StepTwo = ({
                   <div className="column p-0 is-12">
                     <FadeIn>
                       <div className="pl-1 mt-2 mb-4">
-                        <p className="smaller-text has-text-red">
+                        <p className="smaller-text has-text-danger">
                           {errors?.startTime?.message}
                         </p>
                       </div>
@@ -230,7 +230,7 @@ const StepTwo = ({
                   <div className="column p-0 is-12">
                     <FadeIn>
                       <div className="pl-1 mt-2 mb-4">
-                        <p className="smaller-text has-text-red">
+                        <p className="smaller-text has-text-danger">
                           {errors?.endTime?.message}
                         </p>
                       </div>

--- a/frontend/packages/client/src/components/UploadImageModal.js
+++ b/frontend/packages/client/src/components/UploadImageModal.js
@@ -308,13 +308,13 @@ export default function UploadImageModal({
               </div>
             )}
             <div className="py-4">
-              <p className="smaller-text has-text-gray">
+              <p className="smaller-text has-text-grey">
                 Accepted files: PNG, JPG, GIF
               </p>
             </div>
             {errorMessage && (
               <div className="pb-4 transition-all">
-                <p className="smaller-text has-text-red">{errorMessage}</p>
+                <p className="smaller-text has-text-danger">{errorMessage}</p>
               </div>
             )}
             {/* For now this is a single input */}

--- a/frontend/packages/client/src/components/common/Checkbox.js
+++ b/frontend/packages/client/src/components/common/Checkbox.js
@@ -22,7 +22,7 @@ export default function Checkbox({
       {error && (
         <FadeIn>
           <div className="pl-1 mt-2">
-            <p className="smaller-text has-text-red">{error?.message}</p>
+            <p className="smaller-text has-text-danger">{error?.message}</p>
           </div>
         </FadeIn>
       )}

--- a/frontend/packages/client/src/components/common/CustomDatePicker.js
+++ b/frontend/packages/client/src/components/common/CustomDatePicker.js
@@ -51,7 +51,7 @@ export default function CustomDatePicker({
         <div className="column p-0 is-12">
           <FadeIn>
             <div className="pl-1 mt-2 mb-4">
-              <p className="smaller-text has-text-red">{errorMessage}</p>
+              <p className="smaller-text has-text-danger">{errorMessage}</p>
             </div>
           </FadeIn>
         </div>

--- a/frontend/packages/client/src/components/common/Dropdown.js
+++ b/frontend/packages/client/src/components/common/Dropdown.js
@@ -164,7 +164,9 @@ export default function DropdownWrapper({
             {error && (
               <FadeIn>
                 <div className="pl-1 mt-2">
-                  <p className="smaller-text has-text-red">{error?.message}</p>
+                  <p className="smaller-text has-text-danger">
+                    {error?.message}
+                  </p>
                 </div>
               </FadeIn>
             )}

--- a/frontend/packages/client/src/components/common/Editor/DraftjsEditor.js
+++ b/frontend/packages/client/src/components/common/Editor/DraftjsEditor.js
@@ -27,7 +27,7 @@ const link = {
 
 const styleMap = {
   IMAGE_CAPTION: {
-    fontFamily: 'Arimo',
+    fontFamily: 'DM Sans',
     fontStyle: 'normal',
     fontWeight: 400,
     fontSize: '12px',

--- a/frontend/packages/client/src/components/common/Editor/Editor.js
+++ b/frontend/packages/client/src/components/common/Editor/Editor.js
@@ -16,7 +16,7 @@ export default function Editor({ control, error, name } = {}) {
       {error && (
         <FadeIn>
           <div className="pl-1 mt-2">
-            <p className="smaller-text has-text-red">{error?.message}</p>
+            <p className="smaller-text has-text-danger">{error?.message}</p>
           </div>
         </FadeIn>
       )}

--- a/frontend/packages/client/src/components/common/Input.js
+++ b/frontend/packages/client/src/components/common/Input.js
@@ -26,7 +26,7 @@ export default function Input({
       {error && (
         <FadeIn>
           <div className="pl-1 mt-2">
-            <p className="smaller-text has-text-red">{error?.message}</p>
+            <p className="smaller-text has-text-danger">{error?.message}</p>
           </div>
         </FadeIn>
       )}

--- a/frontend/packages/client/src/components/common/TextArea.js
+++ b/frontend/packages/client/src/components/common/TextArea.js
@@ -26,7 +26,7 @@ export default function TextArea({
       {error && (
         <FadeIn>
           <div className="pl-1 mt-2">
-            <p className="smaller-text has-text-red">{error?.message}</p>
+            <p className="smaller-text has-text-danger">{error?.message}</p>
           </div>
         </FadeIn>
       )}

--- a/frontend/packages/client/src/contexts/ErrorHandler.js
+++ b/frontend/packages/client/src/contexts/ErrorHandler.js
@@ -31,7 +31,7 @@ const ErrorHandlerProvider = ({ children }) => {
       openModal(
         React.createElement(Error, {
           error: (
-            <p className="has-text-red p-3 has-text-justified">
+            <p className="has-text-danger p-3 has-text-justified">
               <b>{error.statusText}</b>
             </p>
           ),

--- a/frontend/packages/client/src/index.css
+++ b/frontend/packages/client/src/index.css
@@ -9,7 +9,6 @@ body {
 
 body {
   margin: 0;
-  font-family: 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/frontend/packages/client/src/pages/CommunityCreate.js
+++ b/frontend/packages/client/src/pages/CommunityCreate.js
@@ -131,7 +131,9 @@ export default function CommunityCreate() {
                 <ul>
                   {errorMessages.map((type, index) => (
                     <li key={`error-${index}`}>
-                      <p className="smaller-text mt-2 has-text-red">- {type}</p>
+                      <p className="smaller-text mt-2 has-text-danger">
+                        - {type}
+                      </p>
                     </li>
                   ))}
                 </ul>

--- a/frontend/packages/client/src/pages/Proposal.js
+++ b/frontend/packages/client/src/pages/Proposal.js
@@ -225,7 +225,7 @@ export default function ProposalPage() {
       modalContext.openModal(
         React.createElement(Error, {
           error: (
-            <p className="has-text-red">
+            <p className="has-text-danger">
               <b>{response.error}</b>
             </p>
           ),
@@ -445,7 +445,7 @@ export default function ProposalPage() {
             <div>
               <WrapperResponsive
                 as="h2"
-                classNames="title mt-5 is-4 has-text-back has-text-weight-normal"
+                classNames="title mt-5 is-4 has-text-black has-text-weight-normal"
                 extraStylesMobile={{ marginBottom: '30px' }}
               >
                 {proposal.name}


### PR DESCRIPTION
- remove Arimo/Roboto/Helvetica, make DM Sans the primary font for everything
- refactor color variables, remove unused variables and add "success" and "danger" color for success/error messages
- switch any `gray` classes to `grey` as Bulma uses `grey` convention, refactor grey classes to be simpler
- update some of our grey shades
- remove `$red` and `.has-text-red` as we were using it exclusively for error messages, which in that case we should actually use Bulma's `$danger` and `has-text-danger`

![image](https://user-images.githubusercontent.com/15314629/189222868-f2eb465c-8cb8-46ce-a02e-bb41f939d0f0.png)
