### PR TITLE
remove next button

### DIFF
--- a/frontend/packages/client/src/pages/CommunityCreate.js
+++ b/frontend/packages/client/src/pages/CommunityCreate.js
@@ -163,7 +163,6 @@ export default function CommunityCreate() {
     submittingMessage: 'Creating community...',
     passNextToComp: true,
     passSubmitToComp: true,
-    showActionButtonLeftPannel: true,
     preStep: <StartSteps />,
     blockNavigationOut: true && !data,
     blockNavigationText:


### PR DESCRIPTION
- Fix to hide next button on community creation 
<img width="853" alt="Screen Shot 2022-09-09 at 12 27 13" src="https://user-images.githubusercontent.com/7526740/189386408-9da05d82-d29a-40ac-9f3a-f7ab60a4ffa6.png">
