### PR TITLE
Hotfix: rename cast.png references to .jpg

### DIFF
--- a/frontend/Dockerfile.stage
+++ b/frontend/Dockerfile.stage
@@ -27,7 +27,7 @@ FROM nginx:latest as production-stage
 RUN mkdir -p /var/run/nginx-cache && chmod 0755 /var/run/nginx-cache
 WORKDIR /app
 COPY --from=build-stage /app/packages/client/build /app
-COPY ./packages/client/public/cast.png /app
+COPY ./packages/client/public/cast.jpg /app
 COPY ./deploy/nginx.conf /etc/nginx/nginx.conf
 EXPOSE 80
 RUN ls -la /app

--- a/frontend/deploy/nginx.conf
+++ b/frontend/deploy/nginx.conf
@@ -27,7 +27,7 @@ http {
             index  index.html;
             try_files $uri $uri/ /index.html;
         }
-        location  /app/cast.png{
+        location  /app/cast.jpg{
         }
         location /js/script.js {
         # Change this if you use a different variant of the script

--- a/frontend/packages/client/public/index.html
+++ b/frontend/packages/client/public/index.html
@@ -12,7 +12,7 @@
     <meta property="og:title" content="Cast" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://cast.fyi" />
-    <meta property="og:image" content="%PUBLIC_URL%/cast.png" />
+    <meta property="og:image" content="%PUBLIC_URL%/cast.jpg" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />


### PR DESCRIPTION
Docker images require references of `cast.png` to be updated to `cast.jpg`