### PR TITLE
fix Lilico icon 

### DIFF
--- a/frontend/packages/client/src/components/WalletConnectModal.js
+++ b/frontend/packages/client/src/components/WalletConnectModal.js
@@ -7,7 +7,7 @@ import { ArrowRight, Close } from './Svg';
 
 const getWalletIcon = (provider) => {
   if (provider?.name === 'Lilico') {
-    return provider.icon;
+    return 'https://raw.githubusercontent.com/Outblock/Lilico-Web/main/asset/logo-dis.png';
   }
   return `https://fcl-discovery.onflow.org${provider.icon}`;
 };


### PR DESCRIPTION
- If Lilico extension is not installed then the icon does not render correctly.

<img width="401" alt="Screen Shot 2022-09-12 at 16 21 48" src="https://user-images.githubusercontent.com/7526740/189738262-2a742339-428c-4c9c-a31b-ad5d04c541a7.png">
