### PR TITLE
fix mobile styling for watch icon

### DIFF
--- a/frontend/packages/client/src/components/Community/CommunityCard.js
+++ b/frontend/packages/client/src/components/Community/CommunityCard.js
@@ -74,7 +74,10 @@ const CommunityCard = ({ logo, name, body, id, slug, hideJoin }) => {
               </p>
             </div>
             {!hideJoin && (
-              <div className="column is-12-mobile p-0-mobile is-narrow-tablet is-flex is-flex-direction-column is-justify-content-start">
+              <div
+                className="is-flex is-align-items-center mr-2"
+                style={{ maxWidth: 40 }}
+              >
                 <JoinCommunityButton communityId={id} />
               </div>
             )}


### PR DESCRIPTION
simplify the styles for the container of the watch eye icon that it properly wraps on both desktop and mobile