### PR TITLE
Fix payload missing hexified timestamp

### DIFF
--- a/frontend/packages/client/src/hooks/useCommunityMutation.js
+++ b/frontend/packages/client/src/hooks/useCommunityMutation.js
@@ -56,7 +56,7 @@ export default function useCommunityMutation() {
           logo: communityLogo?.fileUrl,
           bannerImgUrl: communityBanner?.fileUrl,
         },
-        timestamp,
+        timestamp: hexTime,
         compositeSignatures,
         voucher,
       });


### PR DESCRIPTION
- api request from client was not sending the proper payload with timestamp hexified