### PR TITLE
fix cut off logo in some browsers

### DIFF
--- a/frontend/packages/shared-components/src/Svg/Logo.js
+++ b/frontend/packages/shared-components/src/Svg/Logo.js
@@ -1,4 +1,4 @@
-const Logo = ({ width = '146', height = '34' }) => (
+const Logo = ({ width = '146', height = '33' }) => (
   <svg
     width={width}
     height={height}


### PR DESCRIPTION
fixes issue where header logo is cut off on some browsers 
![Screen Shot 2022-09-13 at 12 41 22 AM](https://user-images.githubusercontent.com/15314629/190678709-e2447328-527e-4f89-b078-15d426ddc688.png)
