### PR TITLE
CAS-532 - Fix start time interval

### DIFF
--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -6,7 +6,7 @@ $success: #3EAE4F
 $danger: #F54339
 $yellow: #FBD84D
 $orange: #F4AF4A
-$light-grey: #DCDCDC
+$light-grey: #F9F9F9
 $grey: #636363
 
 // Update Bulma's global variables

--- a/frontend/packages/client/src/components/ProposalCreate/StepTwo/TimeIntervals.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepTwo/TimeIntervals.js
@@ -28,6 +28,10 @@ const isTomorrow = (date) => {
   return date?.setHours(0, 0, 0, 0) === tomorrow.getTime();
 };
 
+// this function check if the user
+// is in the last hour of the day
+// to return the correct interval
+// otherwise returns all intervals
 const getIntervalForTomorrow = () => {
   const now = new Date();
   // In the last hour of the day
@@ -37,20 +41,30 @@ const getIntervalForTomorrow = () => {
   return 0;
 };
 
-export default function TimeIntervals({ date, time, setTime, type } = {}) {
-  const startDateIsToday = date ? isToday(date) : false;
+const getStartTimeIngerval = (startDateIsToday) => {
+  return startDateIsToday ? Date.now() : 0;
+};
+
+const getStartTimeIntervalWithDelay = (date, startDateIsToday) => {
+  if (startDateIsToday) {
+    return new Date(Date.now() + 60 * 60 * 1000);
+  }
 
   const startDateIsTomorrow = date ? isTomorrow(date) : false;
 
+  if (startDateIsTomorrow) {
+    return getIntervalForTomorrow();
+  }
+
+  return 0;
+};
+
+export default function TimeIntervals({ date, time, setTime, type } = {}) {
+  const startDateIsToday = date ? isToday(date) : false;
+
   const startTimeInterval = HAS_DELAY_ON_START_TIME
-    ? startDateIsToday
-      ? new Date(Date.now() + 60 * 60 * 1000)
-      : startDateIsTomorrow
-      ? getIntervalForTomorrow()
-      : 0
-    : startDateIsToday
-    ? Date.now()
-    : 0;
+    ? getStartTimeIntervalWithDelay(date, startDateIsToday)
+    : getStartTimeIngerval(startDateIsToday);
 
   const timeIntervals = getTimeIntervals(startTimeInterval);
 

--- a/frontend/packages/client/src/components/ProposalCreate/StepTwo/TimeIntervals.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepTwo/TimeIntervals.js
@@ -21,13 +21,35 @@ const isToday = (date) => {
   return date?.setHours(0, 0, 0, 0) === new Date().setHours(0, 0, 0, 0);
 };
 
+const isTomorrow = (date) => {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(0, 0, 0, 0);
+  return date?.setHours(0, 0, 0, 0) === tomorrow.getTime();
+};
+
+const getIntervalForTomorrow = () => {
+  const now = new Date();
+  // In the last hour of the day
+  if (now > new Date().setHours(23, 0, 0, 0)) {
+    return new Date().setHours(0, now.getMinutes(), 0, 0);
+  }
+  return 0;
+};
+
 export default function TimeIntervals({ date, time, setTime, type } = {}) {
   const startDateIsToday = date ? isToday(date) : false;
 
-  const startTimeInterval = startDateIsToday
-    ? HAS_DELAY_ON_START_TIME
+  const startDateIsTomorrow = date ? isTomorrow(date) : false;
+
+  const startTimeInterval = HAS_DELAY_ON_START_TIME
+    ? startDateIsToday
       ? new Date(Date.now() + 60 * 60 * 1000)
-      : Date.now()
+      : startDateIsTomorrow
+      ? getIntervalForTomorrow()
+      : 0
+    : startDateIsToday
+    ? Date.now()
     : 0;
 
   const timeIntervals = getTimeIntervals(startTimeInterval);

--- a/frontend/packages/client/src/components/ProposalCreate/StepTwo/TimeIntervals.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepTwo/TimeIntervals.js
@@ -41,7 +41,7 @@ const getIntervalForTomorrow = () => {
   return 0;
 };
 
-const getStartTimeIngerval = (startDateIsToday) => {
+const getStartTimeInterval = (startDateIsToday) => {
   return startDateIsToday ? Date.now() : 0;
 };
 
@@ -64,7 +64,7 @@ export default function TimeIntervals({ date, time, setTime, type } = {}) {
 
   const startTimeInterval = HAS_DELAY_ON_START_TIME
     ? getStartTimeIntervalWithDelay(date, startDateIsToday)
-    : getStartTimeIngerval(startDateIsToday);
+    : getStartTimeInterval(startDateIsToday);
 
   const timeIntervals = getTimeIntervals(startTimeInterval);
 


### PR DESCRIPTION
To test this PR:
- update your machine time to be within the last hour of today
- Create a proposal and select start time of proposal to be tomorrow
- On drop down time for startTime you'll see first minutes interval of the day removed to meet the one hour requirement between time now and start of proposal. 
