### PR TITLE
CAS-539 - style fix on strategy selector

### DIFF
--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -684,6 +684,11 @@ span[data-tooltip]
 	top: 13px
 	left: 3px
 	color: rgb(74 74 74 / 90%)
+
+@media (max-width: 421px)
+	.form-checkbox:checked:after
+		top: 20px !important
+
 .image-caption-draft-js
 	.public-DraftStyleDefault-block.public-DraftStyleDefault-ltr
 		margin: 0px !important

--- a/frontend/packages/client/src/components/Community/CommunityEditorDetails/FormFields.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorDetails/FormFields.js
@@ -36,7 +36,8 @@ export default function Form({
               <input
                 key={addrField.id} // important to include key with field's id
                 placeholder={label || `Enter ${addrType}`}
-                className={`border-light rounded-sm p-3 column is-full ${inputStyle}`}
+                style={{ width: '100%' }}
+                className={`border-light rounded-sm p-3 column is-fullwidth ${inputStyle}`}
                 {...register(`${listName}.${index}.addr`, {
                   disabled: isSubmitting,
                 })}

--- a/frontend/packages/client/src/components/Community/StrategySelectorInput.js
+++ b/frontend/packages/client/src/components/Community/StrategySelectorInput.js
@@ -13,7 +13,7 @@ export default function StrategyInput({
       style={{ position: 'relative' }}
     >
       <div
-        className="border-light rounded-sm p-3 column is-full small-text"
+        className="border-light rounded-sm p-3 pr-6 column is-full small-text"
         style={{
           width: '100%',
           lineHeight: 'normal',


### PR DESCRIPTION
<img width="452" alt="Screen Shot 2022-09-16 at 16 07 41" src="https://user-images.githubusercontent.com/7526740/190714174-6a0504d6-43f1-4804-9a3c-ddf3a08c29b0.png">


Also fixed:
<img width="428" alt="Screen Shot 2022-09-16 at 16 14 42" src="https://user-images.githubusercontent.com/7526740/190714211-51f075ef-ca7f-4a8f-a0b5-e648338fd017.png">
now: 
<img width="428" alt="Screen Shot 2022-09-16 at 16 08 22" src="https://user-images.githubusercontent.com/7526740/190714236-255b1de1-a78e-4411-81ab-b3c180888eb0.png">
After:
<img width="421" alt="Screen Shot 2022-09-16 at 16 14 48" src="https://user-images.githubusercontent.com/7526740/190714260-4ccb2fa2-0f2d-4891-a4b3-1b443a7913ee.png">
Now:
<img width="411" alt="Screen Shot 2022-09-16 at 16 16 56" src="https://user-images.githubusercontent.com/7526740/190714387-3e63c8ff-298e-415a-bb5e-6345530c23e9.png">
