### PR TITLE
cas-577 catch strategy name errors. update tests

### DIFF
--- a/backend/main/server/controllers.go
+++ b/backend/main/server/controllers.go
@@ -78,6 +78,8 @@ var (
 		message:    "Strategy Not Found",
 		details:    "The strategy name you are trying to use no longer exists.",
 	}
+
+	nilErr = errorResponse{}
 )
 
 func (a *App) health(w http.ResponseWriter, r *http.Request) {
@@ -308,7 +310,7 @@ func (a *App) createProposal(w http.ResponseWriter, r *http.Request) {
 	}
 
 	proposal, errResponse := helpers.createProposal(p)
-	if err != nil {
+	if errResponse != nilErr {
 		log.Error().Err(err).Msg("Error creating proposal")
 		respondWithError(w, errResponse)
 		return
@@ -334,7 +336,8 @@ func (a *App) updateProposal(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check that status update is valid
-	// For now we are assuming proposals are creating with status 'published' and may be cancelled.
+	// For now we are assuming proposals are creating with
+	// status 'published' and may be cancelled.
 	if payload.Status != "cancelled" {
 		log.Error().Err(err).Msg("Invalid status update")
 		respondWithError(w, errIncompleteRequest)

--- a/backend/main/server/controllers.go
+++ b/backend/main/server/controllers.go
@@ -71,6 +71,13 @@ var (
 		message:    "Error",
 		details:    "There was an error trying to update your community",
 	}
+
+	errStrategyNotFound = errorResponse{
+		statusCode: http.StatusNotFound,
+		errorCode:  "ERR_1008",
+		message:    "Strategy Not Found",
+		details:    "The strategy name you are trying to use no longer exists.",
+	}
 )
 
 func (a *App) health(w http.ResponseWriter, r *http.Request) {
@@ -300,10 +307,10 @@ func (a *App) createProposal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	proposal, err := helpers.createProposal(p)
+	proposal, errResponse := helpers.createProposal(p)
 	if err != nil {
 		log.Error().Err(err).Msg("Error creating proposal")
-		respondWithError(w, errIncompleteRequest)
+		respondWithError(w, errResponse)
 		return
 	}
 

--- a/backend/main/server/helpers.go
+++ b/backend/main/server/helpers.go
@@ -462,26 +462,30 @@ func (h *Helpers) searchCommunities(query string) ([]models.Community, error) {
 	return results, nil
 }
 
-func (h *Helpers) createProposal(p models.Proposal) (models.Proposal, error) {
+func (h *Helpers) createProposal(p models.Proposal) (models.Proposal, errorResponse) {
+	if err := h.validateStrategyName(p.Name); err != nil {
+		return models.Proposal{}, errStrategyNotFound
+	}
+
 	if p.Voucher != nil {
 		if err := h.validateUserViaVoucher(p.Creator_addr, p.Voucher); err != nil {
-			return models.Proposal{}, err
+			return models.Proposal{}, errForbidden
 		}
 	} else {
 		if err := h.validateUser(p.Creator_addr, p.Timestamp, p.Composite_signatures); err != nil {
-			return models.Proposal{}, err
+			return models.Proposal{}, errForbidden
 		}
 	}
 
 	community, err := h.fetchCommunity(p.Community_id)
 	if err != nil {
-		return models.Proposal{}, err
+		return models.Proposal{}, errIncompleteRequest
 	}
 
 	strategy, err := models.MatchStrategyByProposal(*community.Strategies, *p.Strategy)
 	if err != nil {
 		log.Error().Err(err).Msg("Community does not have this strategy available.")
-		return models.Proposal{}, err
+		return models.Proposal{}, errIncompleteRequest
 
 	}
 
@@ -494,30 +498,30 @@ func (h *Helpers) createProposal(p models.Proposal) (models.Proposal, error) {
 	}
 
 	if err := h.snapshot(&strategy, &p); err != nil {
-		return models.Proposal{}, err
+		return models.Proposal{}, errIncompleteRequest
 	}
 
 	if err := h.enforceCommunityRestrictions(community, p, strategy); err != nil {
-		return models.Proposal{}, err
+		return models.Proposal{}, errIncompleteRequest
 	}
 
 	if err := h.processSnapshotStatus(&strategy, &p); err != nil {
 		errMsg := "Error processing snapshot status."
 		log.Error().Err(err).Msg(errMsg)
-		return models.Proposal{}, err
+		return models.Proposal{}, errIncompleteRequest
 	}
 
 	p.Cid, err = h.pinJSONToIpfs(p)
 	if err != nil {
 		log.Error().Err(err).Msg("IPFS error: " + err.Error())
-		return models.Proposal{}, err
+		return models.Proposal{}, errIncompleteRequest
 	}
 
 	validate := validator.New()
 	vErr := validate.Struct(p)
 	if vErr != nil {
 		log.Error().Err(vErr)
-		return models.Proposal{}, err
+		return models.Proposal{}, errIncompleteRequest
 	}
 
 	if os.Getenv("APP_ENV") == "PRODUCTION" {
@@ -527,10 +531,26 @@ func (h *Helpers) createProposal(p models.Proposal) (models.Proposal, error) {
 	}
 
 	if err := p.CreateProposal(h.A.DB); err != nil {
-		return models.Proposal{}, err
+		return models.Proposal{}, errIncompleteRequest
 	}
 
-	return p, nil
+	return p, errorResponse{}
+}
+
+func (h *Helpers) validateStrategyName(name string) error {
+	if name == "" {
+		return errors.New("Strategy name is required.")
+	}
+
+	for k, _ := range strategyMap {
+		if name == k {
+			return nil
+		} else {
+			return errors.New("Stategy name no longer exists.")
+		}
+	}
+
+	return nil
 }
 
 func (h *Helpers) enforceCommunityRestrictions(

--- a/backend/main/server/helpers.go
+++ b/backend/main/server/helpers.go
@@ -486,7 +486,6 @@ func (h *Helpers) createProposal(p models.Proposal) (models.Proposal, errorRespo
 	if err != nil {
 		log.Error().Err(err).Msg("Community does not have this strategy available.")
 		return models.Proposal{}, errIncompleteRequest
-
 	}
 
 	// Set Min Balance/Max Weight to community defaults if not provided

--- a/backend/main/server/helpers.go
+++ b/backend/main/server/helpers.go
@@ -463,7 +463,8 @@ func (h *Helpers) searchCommunities(query string) ([]models.Community, error) {
 }
 
 func (h *Helpers) createProposal(p models.Proposal) (models.Proposal, errorResponse) {
-	if err := h.validateStrategyName(p.Name); err != nil {
+	if err := h.validateStrategyName(*p.Strategy); err != nil {
+		fmt.Printf("Error validating strategy name: %v \n", err)
 		return models.Proposal{}, errStrategyNotFound
 	}
 
@@ -545,11 +546,11 @@ func (h *Helpers) validateStrategyName(name string) error {
 		if name == k {
 			return nil
 		} else {
-			return errors.New("Stategy name no longer exists.")
+			continue
 		}
 	}
 
-	return nil
+	return errors.New("Strategy not found.")
 }
 
 func (h *Helpers) enforceCommunityRestrictions(

--- a/backend/tests/main_test.go
+++ b/backend/tests/main_test.go
@@ -22,6 +22,73 @@ var otu *utils.OverflowTestUtils
 
 const ServiceAddress = "0xf8d6e0586b0a20c7"
 
+type errorResponse struct {
+	statusCode int
+	errorCode  string
+	message    string
+	details    string
+}
+
+var (
+	errIncompleteRequest = errorResponse{
+		statusCode: http.StatusBadRequest,
+		errorCode:  "ERR_1001",
+		message:    "Error",
+		details:    "There was an error trying to complete your request",
+	}
+
+	errCreateCommunity = errorResponse{
+		statusCode: http.StatusBadRequest,
+		errorCode:  "ERR_1002",
+		message:    "Error",
+		details:    "There was an error trying to create your community",
+	}
+
+	errFetchingBalance = errorResponse{
+		statusCode: http.StatusBadRequest,
+		errorCode:  "ERR_1003",
+		message:    "Error Fetching Balance",
+		details: `While confirming your balance, we've encountered an error
+							connecting to the Flow Blockchain.`,
+	}
+
+	errInsufficientBalance = errorResponse{
+		statusCode: http.StatusUnauthorized,
+		errorCode:  "ERR_1004",
+		message:    "Insufficient Balance",
+		details: `In order to vote on this proposal you must have a minimum 
+							balance of %d %s tokens in your wallet.`,
+	}
+
+	errForbidden = errorResponse{
+		statusCode: http.StatusForbidden,
+		errorCode:  "ERR_1005",
+		message:    "Forbidden",
+		details:    "You are not authorized to perform this action.",
+	}
+
+	errCreateProposal = errorResponse{
+		statusCode: http.StatusForbidden,
+		errorCode:  "ERR_1006",
+		message:    "Error",
+		details:    "There was an error trying to create your proposal",
+	}
+
+	errUpdateCommunity = errorResponse{
+		statusCode: http.StatusForbidden,
+		errorCode:  "ERR_1007",
+		message:    "Error",
+		details:    "There was an error trying to update your community",
+	}
+
+	errStrategyNotFound = errorResponse{
+		statusCode: http.StatusNotFound,
+		errorCode:  "ERR_1008",
+		message:    "Strategy Not Found",
+		details:    "The strategy name you are trying to use no longer exists.",
+	}
+)
+
 func TestMain(m *testing.M) {
 	var err error
 

--- a/backend/tests/proposal_test.go
+++ b/backend/tests/proposal_test.go
@@ -37,12 +37,14 @@ func TestGetProposal(t *testing.T) {
 	t.Run("Should throw an error if proposal with ID doesnt exist", func(t *testing.T) {
 
 		response := otu.GetProposalByIdAPI(communityId, 420)
+		fmt.Printf("Response: %s", response.Body)
 
 		CheckResponseCode(t, http.StatusForbidden, response.Code)
 
-		var m map[string]string
-		json.Unmarshal(response.Body.Bytes(), &m)
-		assert.Equal(t, "ERR_1001", m["errorCode"])
+		var e errorResponse
+		json.Unmarshal(response.Body.Bytes(), &e)
+		fmt.Printf("Error: %v", e)
+		assert.Equal(t, errIncompleteRequest, e)
 	})
 
 	t.Run("Should fetch existing proposal by ID", func(t *testing.T) {
@@ -160,6 +162,8 @@ func TestUpdateProposal(t *testing.T) {
 		var p models.Proposal
 		json.Unmarshal(response.Body.Bytes(), &p)
 
+		fmt.Printf("Proposal ID: %d", p.ID)
+
 		// Get proposal after create
 		response = otu.GetProposalByIdAPI(communityId, p.ID)
 		var created models.Proposal
@@ -168,6 +172,7 @@ func TestUpdateProposal(t *testing.T) {
 		assert.Equal(t, "active", *created.Computed_status)
 
 		cancelPayload := otu.GenerateCancelProposalStruct(authorName, communityId)
+		fmt.Printf("Cancel payload: %v", cancelPayload)
 		response = otu.UpdateProposalAPI(p.ID, cancelPayload)
 		checkResponseCode(t, http.StatusOK, response.Code)
 

--- a/backend/tests/proposal_test.go
+++ b/backend/tests/proposal_test.go
@@ -37,13 +37,10 @@ func TestGetProposal(t *testing.T) {
 	t.Run("Should throw an error if proposal with ID doesnt exist", func(t *testing.T) {
 
 		response := otu.GetProposalByIdAPI(communityId, 420)
-		fmt.Printf("Response: %s", response.Body)
-
 		CheckResponseCode(t, http.StatusForbidden, response.Code)
 
 		var e errorResponse
 		json.Unmarshal(response.Body.Bytes(), &e)
-		fmt.Printf("Error: %v", e)
 		assert.Equal(t, errIncompleteRequest, e)
 	})
 
@@ -162,8 +159,6 @@ func TestUpdateProposal(t *testing.T) {
 		var p models.Proposal
 		json.Unmarshal(response.Body.Bytes(), &p)
 
-		fmt.Printf("Proposal ID: %d", p.ID)
-
 		// Get proposal after create
 		response = otu.GetProposalByIdAPI(communityId, p.ID)
 		var created models.Proposal
@@ -172,7 +167,6 @@ func TestUpdateProposal(t *testing.T) {
 		assert.Equal(t, "active", *created.Computed_status)
 
 		cancelPayload := otu.GenerateCancelProposalStruct(authorName, communityId)
-		fmt.Printf("Cancel payload: %v", cancelPayload)
 		response = otu.UpdateProposalAPI(p.ID, cancelPayload)
 		checkResponseCode(t, http.StatusOK, response.Code)
 


### PR DESCRIPTION
•Adds new `errorResponse : errStrategyNotFound`
•Changes return type of `createProposal` for better error handling. 