### PR TITLE
CAS-581: Hide tooltip in join button on mobile

### DIFF
--- a/frontend/packages/client/src/components/Community/CommunityCard.js
+++ b/frontend/packages/client/src/components/Community/CommunityCard.js
@@ -78,7 +78,10 @@ const CommunityCard = ({ logo, name, body, id, slug, hideJoin }) => {
                 className="is-flex is-align-items-center mr-2"
                 style={{ maxWidth: 40 }}
               >
-                <JoinCommunityButton communityId={id} />
+                <JoinCommunityButton
+                  communityId={id}
+                  hasTooltip={isNotMobile}
+                />
               </div>
             )}
           </div>

--- a/frontend/packages/client/src/components/Community/JoinCommunityButton.js
+++ b/frontend/packages/client/src/components/Community/JoinCommunityButton.js
@@ -12,6 +12,7 @@ export default function JoinCommunityButton({
   onLeaveCommunity = async () => {},
   onJoinCommunity = async () => {},
   size = 'small',
+  hasTooltip = false,
 }) {
   const [isModalErrorOpened, setIsModalErrorOpened] = useState(false);
   const { createCommunityUser, deleteUserFromCommunity } = useJoinCommunity();
@@ -109,7 +110,7 @@ export default function JoinCommunityButton({
       >
         <Svg name="Eye" />
         <Svg name="HideEye" />
-        {!isMember && (
+        {!isMember && hasTooltip && (
           <span className="join-community-cta py-2 px-4 rounded-lg has-text-white has-background-black smaller-text">
             Watch this community
           </span>


### PR DESCRIPTION
Fixes horizontal scrolling on mobile by removing a span element on mobile. This is used for showing a tooltip on desktop. 

<img width="282" alt="Screen Shot 2022-09-29 at 12 04 13" src="https://user-images.githubusercontent.com/7526740/193069670-c4d21ba1-e5da-4427-bd64-c14d98073f12.png">
