### PR TITLE
CAS-594: Return reason if create proposal fails

### DIFF
--- a/backend/main/models/community.go
+++ b/backend/main/models/community.go
@@ -404,9 +404,9 @@ func (c *Community) CanUserCreateProposal(db *s.Database, fa *s.FlowAdapter, add
 
 	// If only authors can submit and user is not an author
 	if *c.Only_authors_to_submit && !response.IsAuthor {
-		reason := fmt.Sprintf("Account %s is not an author for community %d.", address, c.ID)
-		response.Reason = reason
+		response.Reason = fmt.Sprintf("Account %s is not an author for community %d.", address, c.ID)
 		response.HasPermission = false
+		return response
 	}
 
 	// If we can use token threshold
@@ -415,6 +415,7 @@ func (c *Community) CanUserCreateProposal(db *s.Database, fa *s.FlowAdapter, add
 		if err != nil {
 			err = fmt.Errorf("invalid proposal threshold for community %d", c.ID)
 			response.Error = err
+			return response
 		}
 
 		// Get Contract
@@ -434,8 +435,10 @@ func (c *Community) CanUserCreateProposal(db *s.Database, fa *s.FlowAdapter, add
 		if *balance < threshold {
 			reason := "Insufficient token balance to create proposal."
 			response.Reason = reason
+			return response
 		} else {
 			response.HasPermission = true
+			return response
 		}
 	}
 

--- a/backend/main/models/community.go
+++ b/backend/main/models/community.go
@@ -446,7 +446,7 @@ func SearchForCommunity(db *s.Database, query string, filters []string, params s
 	if err != nil {
 		return nil, 0, err
 	}
-	
+
 	rows, err := db.Conn.Query(
 		db.Context,
 		sql,
@@ -503,9 +503,9 @@ func GetCategoryCount(db *s.Database, search string) (map[string]int, error) {
 
 	categoryCount := make(map[string]int)
 	for rows.Next() {
-		results := struct{
+		results := struct {
 			Category string
-			Count int
+			Count    int
 		}{}
 		err := rows.Scan(&results.Category, &results.Count)
 		if err != nil {

--- a/backend/main/models/community.go
+++ b/backend/main/models/community.go
@@ -5,7 +5,6 @@ package models
 /////////////////
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -14,7 +13,6 @@ import (
 	s "github.com/DapperCollectives/CAST/backend/main/shared"
 	"github.com/georgysavva/scany/pgxscan"
 	"github.com/jackc/pgx/v4"
-	"github.com/rs/zerolog/log"
 )
 
 type Community struct {
@@ -91,8 +89,12 @@ type UpdateCommunityRequestPayload struct {
 
 type CanUserCreateProposalResponse struct {
 	shared.Contract
-	Balance       *float64 `json:"balance,omitempty"`
-	HasPermission bool     `json:"hasPermission"`
+	Balance                *float64 `json:"balance,omitempty"`
+	Only_authors_to_submit bool     `json:"onlyAuthorsToSubmit"`
+	IsAuthor               bool     `json:"isAuthor"`
+	HasPermission          bool     `json:"hasPermission"`
+	Reason                 string   `json:"reason,omitempty"`
+	Error                  error    `json:"error,omitempty"`
 }
 
 type Strategy struct {
@@ -386,50 +388,58 @@ func (c *Community) CanUpdateCommunity(db *s.Database, addr string) error {
 	return nil
 }
 
-func (c *Community) CanUserCreateProposal(db *s.Database, fa *s.FlowAdapter, address string) error {
-	var isAuthor = true
-	var errMsg string
+func (c *Community) CanUserCreateProposal(db *s.Database, fa *s.FlowAdapter, address string) CanUserCreateProposalResponse {
+	response := CanUserCreateProposalResponse{}
+	response.Only_authors_to_submit = *c.Only_authors_to_submit
+	response.HasPermission = false // false by default
 
 	// Check if user is an author
 	if err := EnsureRoleForCommunity(db, address, c.ID, "author"); err != nil {
-		isAuthor = false
-		errMsg = fmt.Sprintf("Account %s is not an author for community %d.", address, c.ID)
-		log.Error().Err(err).Msg(errMsg)
+		response.IsAuthor = false
 	} else { // return successfully if user is an author, regardless of Only_authors_to_submit
-		return nil
+		response.IsAuthor = true
+		response.HasPermission = true
+		return response
 	}
 
-	// If only authors can submit
-	if *c.Only_authors_to_submit && !isAuthor {
-		return errors.New(errMsg)
-	}
-	threshold, err := strconv.ParseFloat(*c.Proposal_threshold, 64)
-	if err != nil {
-		log.Error().Err(err).Msg("Invalid proposal threshold")
-		return errors.New("Invalid proposal threshold")
+	// If only authors can submit and user is not an author
+	if *c.Only_authors_to_submit && !response.IsAuthor {
+		reason := fmt.Sprintf("Account %s is not an author for community %d.", address, c.ID)
+		response.Reason = reason
+		response.HasPermission = false
 	}
 
-	contract := shared.Contract{
-		Name:        c.Contract_name,
-		Addr:        c.Contract_addr,
-		Public_path: c.Public_path,
-		Threshold:   &threshold,
-	}
-	balance, err := fa.GetBalanceOfTokens(address, &contract, *c.Contract_type)
-	if err != nil {
-		errMsg := "Error processing Token Threshold."
-		log.Error().Err(err).Msg(errMsg)
-		return errors.New(errMsg)
+	// If we can use token threshold
+	if !*c.Only_authors_to_submit {
+		threshold, err := strconv.ParseFloat(*c.Proposal_threshold, 64)
+		if err != nil {
+			err = fmt.Errorf("invalid proposal threshold for community %d", c.ID)
+			response.Error = err
+		}
+
+		// Get Contract
+		contract := shared.Contract{
+			Name:        c.Contract_name,
+			Addr:        c.Contract_addr,
+			Public_path: c.Public_path,
+			Threshold:   &threshold,
+		}
+		response.Contract = contract
+
+		// Get balance if community has proposal threshold rule
+		balance, _ := fa.GetBalanceOfTokens(address, &contract, *c.Contract_type)
+		response.Balance = balance
+
+		//check if balance is greater than threshold
+		if *balance < threshold {
+			reason := "Insufficient token balance to create proposal."
+			response.Reason = reason
+		} else {
+			response.HasPermission = true
+		}
 	}
 
-	//check if balance is greater than threshold
-	if *balance < threshold {
-		errMsg := "Insufficient token balance to create proposal."
-		log.Error().Err(err).Msg(errMsg)
-		return errors.New(errMsg)
-	}
-
-	return nil
+	return response
 }
 
 func (c *Community) GetStrategy(name string) (Strategy, error) {

--- a/backend/main/server/controllers.go
+++ b/backend/main/server/controllers.go
@@ -106,6 +106,12 @@ var (
 		Message:    "Error",
 		Details:    "There was an error creating the vote.",
 	}
+	errCreateProposalPermissions = errorResponse{
+		StatusCode: http.StatusForbidden,
+		ErrorCode:  "ERR_1013",
+		Message:    "User is not permitted to create a proposal for this community.",
+		Details:    "",
+	}
 
 	nilErr = errorResponse{}
 )
@@ -979,36 +985,10 @@ func (a *App) canUserCreateProposal(w http.ResponseWriter, r *http.Request) {
 		respondWithError(w, errGetCommunity)
 	}
 
-	response := models.CanUserCreateProposalResponse{}
-
-	if !*community.Only_authors_to_submit {
-		threshold, err := strconv.ParseFloat(*community.Proposal_threshold, 64)
-		if err != nil {
-			log.Error().Err(err).Msg("Invalid proposal threshold")
-		}
-
-		// Get Contract
-		contract := shared.Contract{
-			Name:        community.Contract_name,
-			Addr:        community.Contract_addr,
-			Public_path: community.Public_path,
-			Threshold:   &threshold,
-		}
-		response.Contract = contract
-
-		// Get balance if community has proposal threshold rule
-		balance, _ := a.FlowAdapter.GetBalanceOfTokens(addr, &contract, *community.Contract_type)
-		response.Balance = balance
-	}
-
 	// Check if user can create proposal for community
-	if err := community.CanUserCreateProposal(a.DB, a.FlowAdapter, addr); err != nil {
-		response.HasPermission = false
-	} else {
-		response.HasPermission = true
-	}
+	canUserCreateProposal := community.CanUserCreateProposal(a.DB, a.FlowAdapter, addr)
 
-	respondWithJSON(w, http.StatusOK, response)
+	respondWithJSON(w, http.StatusOK, canUserCreateProposal)
 }
 
 /////////////

--- a/backend/main/server/helpers.go
+++ b/backend/main/server/helpers.go
@@ -560,11 +560,18 @@ func (h *Helpers) createProposal(p models.Proposal) (models.Proposal, errorRespo
 		p.Max_weight = strategy.Contract.MaxWeight
 	}
 
-	if err := community.CanUserCreateProposal(h.A.DB, h.A.FlowAdapter, p.Creator_addr); err != nil {
-		return models.Proposal{}, errIncompleteRequest
+	canUserCreateProposal := community.CanUserCreateProposal(h.A.DB, h.A.FlowAdapter, p.Creator_addr)
+
+	// If user doesn't have permission, populate errorResponse
+	// with reason and error.
+	if !canUserCreateProposal.HasPermission {
+		errPermissionsResponse := errCreateProposalPermissions
+		errPermissionsResponse.Message = canUserCreateProposal.Reason
+		errPermissionsResponse.Details = canUserCreateProposal.Error.Error()
+		return models.Proposal{}, errPermissionsResponse
 	}
 
-	// Set Blockheight to latest sealed
+	// Get latest sealed blockheight to use as proposal snapshot
 	blockheight, err := h.A.FlowAdapter.GetCurrentBlockHeight()
 	if err != nil {
 		errMsg := "couldn't fetch current blockheight"

--- a/backend/main/shared/flow.go
+++ b/backend/main/shared/flow.go
@@ -244,7 +244,7 @@ func (fa *FlowAdapter) GetBalanceOfTokens(creatorAddr string, c *Contract, contr
 		// Return 0 balance.
 		var zero float64 = 0.0
 		if err != nil {
-			log.Error().Err(err).Msg("Error executing Funigble-Token Script.")
+			log.Error().Err(err).Msg("Error executing Fungible Token Script.")
 			return &zero, err
 		}
 

--- a/backend/tests/community_test.go
+++ b/backend/tests/community_test.go
@@ -359,7 +359,7 @@ func TestCanUserCreateProposalForCommunityOnlyAuthors(t *testing.T) {
 		json.Unmarshal(response.Body.Bytes(), &responsePayload)
 
 		assert.False(t, responsePayload.HasPermission)
-		assert.Contains(t, "is not an author for community", responsePayload.Reason)
+		assert.Contains(t, responsePayload.Reason, "is not an author for community")
 
 	})
 }

--- a/backend/tests/community_test.go
+++ b/backend/tests/community_test.go
@@ -359,6 +359,7 @@ func TestCanUserCreateProposalForCommunityOnlyAuthors(t *testing.T) {
 		json.Unmarshal(response.Body.Bytes(), &responsePayload)
 
 		assert.False(t, responsePayload.HasPermission)
+		assert.Contains(t, "is not an author for community", responsePayload.Reason)
 
 	})
 }
@@ -428,7 +429,7 @@ func TestCanUserCreateProposalForCommunityTokenThreshold(t *testing.T) {
 		json.Unmarshal(response.Body.Bytes(), &responsePayload)
 
 		assert.False(t, responsePayload.HasPermission)
-
+		assert.Equal(t, "Insufficient token balance to create proposal.", responsePayload.Reason)
 	})
 
 	t.Run("Non-authors should be able to create proposals if they do have enough tokens", func(t *testing.T) {


### PR DESCRIPTION
**Description**

- createProposal error contains reason for failure, if it is a permissions issue
- adds more context + `reason` message to canUserCreateProposal endpoint
- refactors functions to be more re-usable
- adds additional assertions in tests for reason user doesn't have permission to create proposal

**Demo**

`make test`