### PR TITLE
CAS-636: Update Twitter message

### DIFF
--- a/frontend/packages/client/src/components/Proposal/HeaderNavigation.js
+++ b/frontend/packages/client/src/components/Proposal/HeaderNavigation.js
@@ -1,10 +1,23 @@
 import { JoinCommunityButton } from 'components';
-import { useMediaQuery } from 'hooks';
+import { useMediaQuery, useVotesForAddress } from 'hooks';
 import BackButton from './BackButton';
 import ShareDropdown from './ShareDropdown';
 
-const HeaderNavigation = ({ communityId, proposalId, proposalName } = {}) => {
+const HeaderNavigation = ({
+  communityId,
+  proposalId,
+  proposalName,
+  addr,
+} = {}) => {
   const notMobile = useMediaQuery();
+
+  const { data: proposalVoteFromUser } = useVotesForAddress({
+    enabled: Boolean(addr && proposalId),
+    proposalIds: [proposalId],
+    addr,
+  });
+
+  const userVoted = proposalVoteFromUser?.length > 0;
 
   return (
     <div
@@ -22,6 +35,7 @@ const HeaderNavigation = ({ communityId, proposalId, proposalName } = {}) => {
           communityId={communityId}
           proposalId={proposalId}
           proposalName={proposalName}
+          userVoted={userVoted}
         />
       </div>
     </div>

--- a/frontend/packages/client/src/components/Proposal/ShareDropdown.js
+++ b/frontend/packages/client/src/components/Proposal/ShareDropdown.js
@@ -10,6 +10,7 @@ export default function ShareDropdown({
   proposalId,
   proposalName = '',
   isMobile,
+  userVoted,
 } = {}) {
   const [dropdownStatus, setDropdownStatus] = useState('');
   const dropdownRef = useRef();
@@ -29,8 +30,11 @@ export default function ShareDropdown({
   const proposalUrl = `${FRONTEND_URL}/#/community/${communityId}/proposal/${proposalId}`;
 
   const twitterPost = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-    `I just voted on ${proposalName} on CAST! ${proposalUrl} `
+    userVoted
+      ? `I just voted on ${proposalName} on CAST! ${proposalUrl}`
+      : `Check out ${proposalName} on CAST! ${proposalUrl}`
   )} `;
+
   return (
     <div className={`dropdown ${dropdownStatus} is-right`}>
       <div className="dropdown-trigger">

--- a/frontend/packages/client/src/pages/Proposal.js
+++ b/frontend/packages/client/src/pages/Proposal.js
@@ -312,6 +312,7 @@ export default function ProposalPage() {
             communityId={proposal.communityId}
             proposalId={proposal.id}
             proposalName={proposal.name}
+            addr={user?.addr}
           />
           {cancelled && (
             <Message messageText={`This proposal has been cancelled`} />


### PR DESCRIPTION
Creates an additional message that is generic this scenarios:
 'Check out <proposal name> on CAST![[proposalURL]]'.

- User without a connected wallet sharing the proposal over twitter
- User sharing an upcoming, closed or cancelled proposal over twiter
- User with a connected wallet sharing a proposal they did not vote on