### PR TITLE
VSL-241 - add PostVoteOptions after voting on proposal

### DIFF
--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -475,6 +475,8 @@ hr
 		max-width: 960px
 		padding-left: 0
 		padding-right: 0
+	.is-flex-direction-row-desktop-only
+		flex-direction: row !important
 
 @include tablet-only
 	.spacing-left-panel

--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -306,10 +306,7 @@ header#navbar
 hr
 	border: 1px solid $grey-lightest
 .vote-options .is-disabled
-	opacity: 0.5
 	pointer-events: none
-.vote-options .is-disabled.is-voted
-	opacity: 1
 .dropdown.is-disabled
 	background-color: rgba(239, 239, 239, 0.3)
 	pointer-events: none

--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -9,6 +9,7 @@ $orange: #F4AF4A
 $light-grey: #F9F9F9
 $grey: #636363
 $light-blue: hsla(211, 98%, 46%, 1)
+$blue-twitter: #1DA1F2
 
 // Update Bulma's global variables
 $family-sans-serif: "DM Sans"
@@ -304,14 +305,18 @@ header#navbar
 	display: none
 hr
 	border: 1px solid $grey-lightest
-.vote-options.is-disabled
+.vote-options .is-disabled
 	opacity: 0.5
 	pointer-events: none
-.vote-options.is-disabled.is-voted
+.vote-options .is-disabled.is-voted
 	opacity: 1
 .dropdown.is-disabled
 	background-color: rgba(239, 239, 239, 0.3)
 	pointer-events: none
+.twitter-button, .twitter-button:hover
+	background: $blue-twitter !important
+	border-color: $blue-twitter !important
+	color: white !important
 .join-community-button
 	transition: all .3s
 	.hide-eye

--- a/frontend/packages/client/src/components/Proposal/VoteOptions/PostVoteOptions.js
+++ b/frontend/packages/client/src/components/Proposal/VoteOptions/PostVoteOptions.js
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { useModalContext } from 'contexts/NotificationModal';
 import { Svg } from '@cast/shared-components';
+import { Tooltip } from 'components';
 import NotificationsModal from 'components/modals/Notifications';
 import { FRONTEND_URL } from 'const';
 import classnames from 'classnames';
@@ -18,6 +19,16 @@ const PostVoteOptions = ({ communityId, proposalId }) => {
     );
 
   const proposalUrl = `${FRONTEND_URL}/#/community/${communityId}/proposal/${proposalId}`;
+
+  useEffect(() => {
+    let timeout;
+    if (linkCopied) {
+      timeout = setTimeout(() => {
+        setLinkCopied(false);
+      }, 500);
+    }
+    return () => clearTimeout(timeout);
+  }, [linkCopied]);
 
   const buttonsContainerClasses = classnames(
     'is-flex is-flex-wrap-wrap is-flex-direction-column',
@@ -54,17 +65,23 @@ const PostVoteOptions = ({ communityId, proposalId }) => {
           className="column is-full-mobile p-0 mx-2-desktop mb-2"
           style={{ flexGrow: 0 }}
         >
-          <CopyToClipboard
-            text={window?.location?.href}
-            onCopy={() => setLinkCopied(true)}
+          <Tooltip
+            classNames="is-flex is-flex-grow-1 is-align-items-center transition-all"
+            position="top"
+            text="Copied!"
+            alwaysVisible={true}
+            enabled={linkCopied}
           >
-            <div className="is-flex flex-1 is-align-items-center rounded-lg button">
-              <Svg name="Copy" />
-              <span className="ml-1">
-                {linkCopied ? 'Link Copied!' : 'Copy Link'}
-              </span>
-            </div>
-          </CopyToClipboard>
+            <CopyToClipboard
+              text={window?.location?.href}
+              onCopy={() => setLinkCopied(true)}
+            >
+              <div className="is-flex flex-1 is-align-items-center rounded-lg button">
+                <Svg name="Copy" />
+                <span className="ml-1">Copy Link</span>
+              </div>
+            </CopyToClipboard>
+          </Tooltip>
         </div>
         <div
           className="column is-full-mobile p-0 ml-2-desktop mb-2"

--- a/frontend/packages/client/src/components/Proposal/VoteOptions/PostVoteOptions.js
+++ b/frontend/packages/client/src/components/Proposal/VoteOptions/PostVoteOptions.js
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { useModalContext } from 'contexts/NotificationModal';
+import { Svg } from '@cast/shared-components';
+import NotificationsModal from 'components/modals/Notifications';
+
+const PostVoteOptions = ({ communityId }) => {
+  const [linkCopied, setLinkCopied] = useState(false);
+  const { openModal, closeModal } = useModalContext();
+  const openNotificationsModal = () =>
+    openModal(
+      <NotificationsModal onClose={closeModal} communityId={communityId} />,
+      {
+        classNameModalContent: 'modal-content-sm',
+      }
+    );
+  return (
+    <div className="">
+      <div className="is-flex is-align-items-center">
+        <Svg name="CheckMark" />
+        <b className="is-size-4 ml-2">
+          You successfully voted on this proposal!
+        </b>
+      </div>
+      <div className="is-flex is-align-items-center mt-5">
+        <div className="is-flex flex-1 is-align-items-center rounded-lg button twitter-button mr-2">
+          <Svg name="Twitter" />
+          <span className="ml-1">Share on Twitter</span>
+        </div>
+        <CopyToClipboard
+          text={window?.location?.href}
+          onCopy={() => setLinkCopied(true)}
+        >
+          <div className="is-flex flex-1 is-align-items-center rounded-lg button mx-2">
+            <Svg name="Copy" />
+            <span className="ml-1">
+              {linkCopied ? 'Link Copied!' : 'Copy Link'}
+            </span>
+          </div>
+        </CopyToClipboard>
+        <div
+          className="is-flex flex-1 is-align-items-center rounded-lg button ml-2"
+          onClick={openNotificationsModal}
+        >
+          <Svg name="Bell" />
+          <span className="ml-1">Subscribe for Updates</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PostVoteOptions;

--- a/frontend/packages/client/src/components/Proposal/VoteOptions/PostVoteOptions.js
+++ b/frontend/packages/client/src/components/Proposal/VoteOptions/PostVoteOptions.js
@@ -4,6 +4,7 @@ import { useModalContext } from 'contexts/NotificationModal';
 import { Svg } from '@cast/shared-components';
 import NotificationsModal from 'components/modals/Notifications';
 import { FRONTEND_URL } from 'const';
+import classnames from 'classnames';
 
 const PostVoteOptions = ({ communityId, proposalId }) => {
   const [linkCopied, setLinkCopied] = useState(false);
@@ -18,6 +19,12 @@ const PostVoteOptions = ({ communityId, proposalId }) => {
 
   const proposalUrl = `${FRONTEND_URL}/#/community/${communityId}/proposal/${proposalId}`;
 
+  const buttonsContainerClasses = classnames(
+    'is-flex is-flex-wrap-wrap is-flex-direction-column',
+    'is-flex-direction-row-desktop-only is-justify-content-center',
+    'mt-5 m-0 columns is-mobile p-0'
+  );
+
   return (
     <div className="">
       <div className="is-flex is-align-items-center">
@@ -26,7 +33,7 @@ const PostVoteOptions = ({ communityId, proposalId }) => {
           You successfully voted on this proposal!
         </b>
       </div>
-      <div className="is-flex is-flex-wrap-wrap is-flex-direction-column is-flex-direction-row-desktop-only is-justify-content-center mt-5 columns is-mobile p-0">
+      <div className={buttonsContainerClasses}>
         <div
           className="column is-full-mobile p-0 mr-2-desktop mb-2"
           style={{ flexGrow: 0 }}

--- a/frontend/packages/client/src/components/Proposal/VoteOptions/PostVoteOptions.js
+++ b/frontend/packages/client/src/components/Proposal/VoteOptions/PostVoteOptions.js
@@ -3,8 +3,9 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { useModalContext } from 'contexts/NotificationModal';
 import { Svg } from '@cast/shared-components';
 import NotificationsModal from 'components/modals/Notifications';
+import { FRONTEND_URL } from 'const';
 
-const PostVoteOptions = ({ communityId }) => {
+const PostVoteOptions = ({ communityId, proposalId }) => {
   const [linkCopied, setLinkCopied] = useState(false);
   const { openModal, closeModal } = useModalContext();
   const openNotificationsModal = () =>
@@ -14,6 +15,9 @@ const PostVoteOptions = ({ communityId }) => {
         classNameModalContent: 'modal-content-sm',
       }
     );
+
+  const proposalUrl = `${FRONTEND_URL}/#/community/${communityId}/proposal/${proposalId}`;
+
   return (
     <div className="">
       <div className="is-flex is-align-items-center">
@@ -23,10 +27,17 @@ const PostVoteOptions = ({ communityId }) => {
         </b>
       </div>
       <div className="is-flex is-align-items-center mt-5">
-        <div className="is-flex flex-1 is-align-items-center rounded-lg button twitter-button mr-2">
+        <a
+          className="is-flex flex-1 is-align-items-center rounded-lg button twitter-button mr-2"
+          href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(
+            proposalUrl
+          )}`}
+          target="_blank"
+          rel="noreferrer noopenner"
+        >
           <Svg name="Twitter" />
           <span className="ml-1">Share on Twitter</span>
-        </div>
+        </a>
         <CopyToClipboard
           text={window?.location?.href}
           onCopy={() => setLinkCopied(true)}

--- a/frontend/packages/client/src/components/Proposal/VoteOptions/PostVoteOptions.js
+++ b/frontend/packages/client/src/components/Proposal/VoteOptions/PostVoteOptions.js
@@ -26,35 +26,50 @@ const PostVoteOptions = ({ communityId, proposalId }) => {
           You successfully voted on this proposal!
         </b>
       </div>
-      <div className="is-flex is-align-items-center mt-5">
-        <a
-          className="is-flex flex-1 is-align-items-center rounded-lg button twitter-button mr-2"
-          href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(
-            proposalUrl
-          )}`}
-          target="_blank"
-          rel="noreferrer noopenner"
-        >
-          <Svg name="Twitter" />
-          <span className="ml-1">Share on Twitter</span>
-        </a>
-        <CopyToClipboard
-          text={window?.location?.href}
-          onCopy={() => setLinkCopied(true)}
-        >
-          <div className="is-flex flex-1 is-align-items-center rounded-lg button mx-2">
-            <Svg name="Copy" />
-            <span className="ml-1">
-              {linkCopied ? 'Link Copied!' : 'Copy Link'}
-            </span>
-          </div>
-        </CopyToClipboard>
+      <div className="is-flex is-flex-wrap-wrap is-flex-direction-column is-flex-direction-row-desktop-only is-justify-content-center mt-5 columns is-mobile p-0">
         <div
-          className="is-flex flex-1 is-align-items-center rounded-lg button ml-2"
-          onClick={openNotificationsModal}
+          className="column is-full-mobile p-0 mr-2-desktop mb-2"
+          style={{ flexGrow: 0 }}
         >
-          <Svg name="Bell" />
-          <span className="ml-1">Subscribe for Updates</span>
+          <a
+            className="is-flex flex-1 is-align-items-center rounded-lg button twitter-button"
+            href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(
+              proposalUrl
+            )}`}
+            target="_blank"
+            rel="noreferrer noopenner"
+          >
+            <Svg name="Twitter" />
+            <span className="ml-1">Share on Twitter</span>
+          </a>
+        </div>
+        <div
+          className="column is-full-mobile p-0 mx-2-desktop mb-2"
+          style={{ flexGrow: 0 }}
+        >
+          <CopyToClipboard
+            text={window?.location?.href}
+            onCopy={() => setLinkCopied(true)}
+          >
+            <div className="is-flex flex-1 is-align-items-center rounded-lg button">
+              <Svg name="Copy" />
+              <span className="ml-1">
+                {linkCopied ? 'Link Copied!' : 'Copy Link'}
+              </span>
+            </div>
+          </CopyToClipboard>
+        </div>
+        <div
+          className="column is-full-mobile p-0 ml-2-desktop mb-2"
+          style={{ flexGrow: 0 }}
+        >
+          <div
+            className="is-flex flex-1 is-align-items-center rounded-lg button"
+            onClick={openNotificationsModal}
+          >
+            <Svg name="Bell" />
+            <span className="ml-1">Subscribe for Updates</span>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/packages/client/src/components/Proposal/VoteOptions/VoteOptions.js
+++ b/frontend/packages/client/src/components/Proposal/VoteOptions/VoteOptions.js
@@ -5,6 +5,7 @@ import { FilterValues } from 'const';
 import { getProposalType, parseDateFromServer } from 'utils';
 import { getStatus } from '../getStatus';
 import ImageBasedOptions from './ImageBasedOptions';
+import PostVoteOptions from './PostVoteOptions';
 import TextBasedOptions from './TextBasedOptions';
 import VoteHeader from './VoteHeader';
 
@@ -45,9 +46,9 @@ const VoteOptions = ({
 
   const canVote = isActive && (hasntVoted || !loggedIn);
 
-  const voteClasses = `vote-options border-light rounded mb-6${
-    !hasntVoted ? ' is-voted' : ''
-  }`;
+  const voteClasses = 'vote-options border-light rounded mb-6$';
+  const disabledClass = !canVote ? 'is-disabled' : '';
+  const votedClass = !hasntVoted ? 'is-voted' : '';
 
   let previousVote = castVote;
   let currentOption = optionChosen;
@@ -94,28 +95,34 @@ const VoteOptions = ({
         extraClasses="px-6 pt-6 pb-6"
         extraClassesMobile="px-4 pt-6 pb-6"
       >
-        <VoteHeader status={headerStatus} />
+        {hasntVoted ? (
+          <VoteHeader status={headerStatus} />
+        ) : (
+          <PostVoteOptions communityId={proposal.commmunityId} />
+        )}
       </Wrapper>
-      {!isImageChoice && (
-        <TextBasedOptions
-          choices={choices}
-          currentOption={currentOption}
-          hideVoteButton={previousVote || isClosed}
-          labelType={labelType}
-          onOptionSelect={isClosed ? () => {} : onOptionSelect}
-          readOnly={isClosed || !canVote}
-          onConfirmVote={onConfirmVote}
-        />
-      )}
-      {isImageChoice && (
-        <ImageBasedOptions
-          choiceA={choiceA}
-          choiceB={choiceB}
-          currentOption={currentOption}
-          readOnly={isClosed || !canVote}
-          confirmAndVote={confirmAndVoteImage}
-        />
-      )}
+      <div className={`${disabledClass} ${votedClass}`}>
+        {!isImageChoice && (
+          <TextBasedOptions
+            choices={choices}
+            currentOption={currentOption}
+            hideVoteButton={previousVote || isClosed}
+            labelType={labelType}
+            onOptionSelect={isClosed ? () => {} : onOptionSelect}
+            readOnly={isClosed || !canVote}
+            onConfirmVote={onConfirmVote}
+          />
+        )}
+        {isImageChoice && (
+          <ImageBasedOptions
+            choiceA={choiceA}
+            choiceB={choiceB}
+            currentOption={currentOption}
+            readOnly={isClosed || !canVote}
+            confirmAndVote={confirmAndVoteImage}
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/packages/client/src/components/Proposal/VoteOptions/VoteOptions.js
+++ b/frontend/packages/client/src/components/Proposal/VoteOptions/VoteOptions.js
@@ -48,7 +48,6 @@ const VoteOptions = ({
 
   const voteClasses = 'vote-options border-light rounded mb-6$';
   const disabledClass = !canVote ? 'is-disabled' : '';
-  const votedClass = !hasntVoted ? 'is-voted' : '';
 
   let previousVote = castVote;
   let currentOption = optionChosen;
@@ -98,10 +97,13 @@ const VoteOptions = ({
         {hasntVoted ? (
           <VoteHeader status={headerStatus} />
         ) : (
-          <PostVoteOptions communityId={proposal.commmunityId} />
+          <PostVoteOptions
+            communityId={proposal.communityId}
+            proposalId={proposal.id}
+          />
         )}
       </Wrapper>
-      <div className={`${disabledClass} ${votedClass}`}>
+      <div className={disabledClass}>
         {!isImageChoice && (
           <TextBasedOptions
             choices={choices}

--- a/frontend/packages/client/src/components/index.js
+++ b/frontend/packages/client/src/components/index.js
@@ -60,4 +60,5 @@ export { default as StatusPill } from './StatusPill';
 export { default as StyledStatusPill } from './StyledStatusPill';
 export { default as FilterPill } from './FilterPill';
 export { default as BrowseCommunityButton } from './BrowseCommunityButton';
+export { default as Tooltip } from './Tooltip';
 export * from './Proposal';


### PR DESCRIPTION
builds upon https://github.com/DapperCollectives/CAST/pull/632 and adds a `PostVoteOptions` component that is to be shown after a user has voted. note that the twitter button doesnt work at the moment as it will be implemented in a follow up PR/ticket

![image](https://user-images.githubusercontent.com/15314629/195910859-ab7d2834-f602-4cb0-937d-b9b1ca6cedd9.png)
