### PR TITLE
CAS-673: Fix update proposal payload

### DIFF
--- a/frontend/packages/client/src/api/proposals.js
+++ b/frontend/packages/client/src/api/proposals.js
@@ -87,7 +87,8 @@ export const updateProposalApiReq = async ({
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      ...updatePayload,
+      payload: updatePayload,
+      signingAddr: updatePayload.signingAddr,
       timestamp,
       compositeSignatures,
       voucher,


### PR DESCRIPTION
The update proposal payload was incorrect and did not provide the payload field containing the updated status.

I am not sure if the fix I made is the correct fix, but it works now. Assuming it worked before, so not sure whether the back-end was updated and that broke it, or the front-end.