### PR TITLE
manny/vsl-264: standardize input and add red color to border

### DIFF
--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -149,6 +149,8 @@ code
 	border-radius: 50%
 .border-light
 	border: 1px solid $grey-lighter
+.border-danger
+	border: 1px solid $danger
 @include tablet	
 	.border-light-tablet
 		border: 1px solid $grey-lighter

--- a/frontend/packages/client/src/components/Community/CommunityEditorProfile/FormFields.js
+++ b/frontend/packages/client/src/components/Community/CommunityEditorProfile/FormFields.js
@@ -19,7 +19,7 @@ export default function FormFields({
         name="communityName"
         disabled={isSubmitting}
         error={errors['communityName']}
-        classNames="rounded-sm border-light p-3 column is-full mt-2"
+        classNames="mt-2"
       />
       <TextArea
         placeholder="Short Description"
@@ -46,7 +46,7 @@ export default function FormFields({
         name="communityTerms"
         disabled={isSubmitting}
         error={errors['communityTerms']}
-        classNames="rounded-sm border-light p-3 column is-full mt-4"
+        classNames="mt-4"
       />
     </>
   );

--- a/frontend/packages/client/src/components/Community/ProposalThresholdEditor/ThresholdForm.js
+++ b/frontend/packages/client/src/components/Community/ProposalThresholdEditor/ThresholdForm.js
@@ -60,7 +60,7 @@ export default function ThresholdForm({
           name="contractAddress"
           disabled={isSubmitting}
           error={errors['contractAddress']}
-          classNames="rounded-sm border-light p-3 column is-full is-full-mobile mt-4"
+          classNames="is-full-mobile mt-4"
         />
         <Input
           placeholder="Contract Name"
@@ -68,7 +68,7 @@ export default function ThresholdForm({
           name="contractName"
           disabled={isSubmitting}
           error={errors['contractName']}
-          classNames="rounded-sm border-light p-3 column is-full is-full-mobile mt-4"
+          classNames="is-full-mobile mt-4"
         />
         <Input
           placeholder="Collection Public Path"
@@ -76,7 +76,7 @@ export default function ThresholdForm({
           register={register}
           disabled={isSubmitting}
           error={errors['storagePath']}
-          classNames="rounded-sm border-light p-3 column is-full is-full-mobile mt-4"
+          classNames="is-full-mobile mt-4"
         />
         <Input
           placeholder="Number of Tokens"
@@ -84,7 +84,7 @@ export default function ThresholdForm({
           register={register}
           disabled={isSubmitting}
           error={errors['proposalThreshold']}
-          classNames="rounded-sm border-light p-3 column is-full is-full-mobile mt-4"
+          classNames="is-full-mobile mt-4"
         />
         <Checkbox
           type="checkbox"

--- a/frontend/packages/client/src/components/Community/StrategyEditorModal/CustomScriptSelector.js
+++ b/frontend/packages/client/src/components/Community/StrategyEditorModal/CustomScriptSelector.js
@@ -95,7 +95,7 @@ export default function CustomScriptSelector({
             register={register}
             error={errors[field]}
             disabled={isSubmitting}
-            classNames="rounded-sm border-light p-3 column is-full is-full-mobile mt-4"
+            classNames="is-full-mobile mt-4"
           />
         ))}
       </div>

--- a/frontend/packages/client/src/components/Community/StrategyEditorModal/StrategyInformationForm.js
+++ b/frontend/packages/client/src/components/Community/StrategyEditorModal/StrategyInformationForm.js
@@ -60,7 +60,7 @@ export default function StrategyInformationForm({
             register={register}
             error={errors[field]}
             disabled={isSubmitting}
-            classNames="rounded-sm border-light p-3 column is-full is-full-mobile mt-4"
+            classNames="is-full-mobile mt-4"
           />
         ))}
       </div>

--- a/frontend/packages/client/src/components/ProposalCreate/StepOne/index.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepOne/index.js
@@ -62,7 +62,6 @@ const StepOne = ({
             voted on. Best to keep it simple and specific.
           </p>
           <Input
-            classNames="rounded-sm border-light p-3 column is-full"
             register={register}
             error={errors['name']}
             name="name"

--- a/frontend/packages/client/src/components/ProposalCreate/StepTwo/StepTwo.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepTwo/StepTwo.js
@@ -125,16 +125,14 @@ const StepTwo = ({
             <>
               <Input
                 placeholder="Minimum Balance"
-                classNames="rounded-sm border-light p-3 column is-full"
-                conatinerClassNames="mt-4 mb-4"
+                containerClassNames="mt-4 mb-4"
                 register={register}
                 error={errors['minBalance']}
                 name="minBalance"
               />
               <Input
                 placeholder="Maximum Weight"
-                classNames="rounded-sm border-light p-3 column is-full"
-                conatinerClassNames="mb-4"
+                containerClassNames="mb-4"
                 register={register}
                 error={errors['maxWeight']}
                 name="maxWeight"

--- a/frontend/packages/client/src/components/common/Input.js
+++ b/frontend/packages/client/src/components/common/Input.js
@@ -1,4 +1,5 @@
 import FadeIn from 'components/FadeIn';
+import classnames from 'classnames';
 
 export default function Input({
   style = {},
@@ -9,21 +10,31 @@ export default function Input({
   disabled,
   error,
   type = 'text',
-  conatinerClassNames = '',
+  containerClassNames = '',
   currentLength,
   maxLengthSize,
 } = {}) {
   const showCharCount = Boolean(currentLength && maxLengthSize);
+  const borderClass = error ? 'border-danger' : 'border-light';
+  const inputClasses = classnames(
+    'column is-full rounded-sm p-3',
+    classNames,
+    borderClass,
+    {
+      'pr-7': showCharCount,
+    }
+  );
+
   return (
     <div
-      className={`is-flex is-flex-direction-column flex-1 ${conatinerClassNames}`.trim()}
+      className={`is-flex is-flex-direction-column flex-1 ${containerClassNames}`.trim()}
       style={showCharCount ? { position: 'relative' } : {}}
     >
       <input
         type={type}
         style={{ width: '100%', ...style }}
         placeholder={placeholder}
-        className={showCharCount ? `${classNames} pr-7` : classNames}
+        className={inputClasses}
         {...register(name, { disabled })}
       />
       {showCharCount && (


### PR DESCRIPTION
- standardized input classnames that were used in every instance of `Input`: `rounded-sm border-light p-3 column is-full`
-  default to `border-light` unless there is an error in which case use `border-danger`

![image](https://user-images.githubusercontent.com/15314629/198363078-98ad09bd-4a88-49ea-80c8-73659998a821.png)
