### PR TITLE
CAS-674: Enable next button on form with dirty field status

### DIFF
--- a/frontend/packages/client/src/components/ProposalCreate/StepOne/index.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepOne/index.js
@@ -60,10 +60,12 @@ const StepOne = ({
   }, [communityName]);
 
   useEffect(() => {
-    if (isStepValid !== isValid) {
-      setStepValid(isValid);
+    // setting is valid to allow move forward to trigger validaiton
+    // if form is not valid isValid will be set to false and will update here
+    if (isStepValid !== (isValid || isDirty)) {
+      setStepValid(isValid || isDirty);
     }
-  }, [isValid, isStepValid, setStepValid]);
+  }, [isValid, isStepValid, setStepValid, isDirty]);
 
   useEffect(() => {
     if (stepStatus === 'submitted' && isDirty) {

--- a/frontend/packages/client/src/components/ProposalCreate/StepOne/index.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepOne/index.js
@@ -60,8 +60,9 @@ const StepOne = ({
   }, [communityName]);
 
   useEffect(() => {
-    // setting is valid to allow move forward to trigger validaiton
-    // if form is not valid isValid will be set to false and will update here
+    // setting is valid to allow move forward to trigger validation
+    // if form is not valid after trying to submit
+    // isValid will be set to false and will update here
     if (isStepValid !== (isValid || isDirty)) {
       setStepValid(isValid || isDirty);
     }

--- a/frontend/packages/client/src/components/ProposalCreate/StepThree/StepThree.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepThree/StepThree.js
@@ -98,8 +98,9 @@ const StepThree = ({
   const { startDate, startTime, endDate, endTime } = allFields;
 
   useEffect(() => {
-    // setting is valid to allow move forward to trigger validaiton
-    // if form is not valid isValid will be set to false and will update here
+    // setting is valid to allow move forward to trigger validation
+    // if form is not valid after trying to submit
+    // isValid will be set to false and will update here
     if (isStepValid !== (isValid || isDirty)) {
       setStepValid(isValid || isDirty);
     }

--- a/frontend/packages/client/src/components/ProposalCreate/StepThree/StepThree.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepThree/StepThree.js
@@ -74,7 +74,7 @@ const StepThree = ({
     field === 'startTime' ? setStartTimeOpen(false) : setEndTimeOpen(false);
   };
 
-  const { errors, isValid } = formState;
+  const { errors, isValid, isDirty } = formState;
 
   const onSubmit = () => {
     onSubmitParam();
@@ -98,10 +98,12 @@ const StepThree = ({
   const { startDate, startTime, endDate, endTime } = allFields;
 
   useEffect(() => {
-    if (isStepValid !== isValid) {
-      setStepValid(isValid);
+    // setting is valid to allow move forward to trigger validaiton
+    // if form is not valid isValid will be set to false and will update here
+    if (isStepValid !== (isValid || isDirty)) {
+      setStepValid(isValid || isDirty);
     }
-  }, [isValid, isStepValid, setStepValid]);
+  }, [isValid, isStepValid, setStepValid, isDirty]);
 
   // pre saves data so when submit
   // is triggered onDataChange has been already executed

--- a/frontend/packages/client/src/components/ProposalCreate/StepTwo/StepTwo.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepTwo/StepTwo.js
@@ -99,8 +99,9 @@ const StepTwo = ({
   const { isSubmitting, isValid, errors, isDirty } = formState;
 
   useEffect(() => {
-    // setting is valid to allow move forward to trigger validaiton
-    // if form is not valid isValid will be set to false and will update here
+    // setting is valid to allow move forward to trigger validation
+    // if form is not valid after trying to submit
+    // isValid will be set to false and will update here
     if (isStepValid !== (isValid || isDirty)) {
       setStepValid(isValid || isDirty);
     }

--- a/frontend/packages/client/src/components/ProposalCreate/StepTwo/StepTwo.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepTwo/StepTwo.js
@@ -99,10 +99,12 @@ const StepTwo = ({
   const { isSubmitting, isValid, errors, isDirty } = formState;
 
   useEffect(() => {
-    if (isStepValid !== isValid) {
-      setStepValid(isValid);
+    // setting is valid to allow move forward to trigger validaiton
+    // if form is not valid isValid will be set to false and will update here
+    if (isStepValid !== (isValid || isDirty)) {
+      setStepValid(isValid || isDirty);
     }
-  }, [isValid, isStepValid, setStepValid]);
+  }, [isValid, isStepValid, setStepValid, isDirty]);
 
   useEffect(() => {
     setIsMovingNextStep(isSubmitting);


### PR DESCRIPTION
Some field arrays are not validated onChange mode, this enables next button to trigger validation. This happens when switching from/to ranked-vote-choice single choice