### PR TITLE
CAS-700: Make start time wait to be 10 mins

### DIFF
--- a/frontend/packages/client/src/components/ProposalCreate/StepThree/TimeIntervals.js
+++ b/frontend/packages/client/src/components/ProposalCreate/StepThree/TimeIntervals.js
@@ -47,7 +47,7 @@ const getStartTimeInterval = (startDateIsToday) => {
 
 const getStartTimeIntervalWithDelay = (date, startDateIsToday) => {
   if (startDateIsToday) {
-    return new Date(Date.now() + 60 * 60 * 1000);
+    return new Date(Date.now() + 10 * 60 * 1000);
   }
 
   const startDateIsTomorrow = date ? isTomorrow(date) : false;


### PR DESCRIPTION
- Next nearest start time in production is now 10 minutes, before it was 60 mins