### PR TITLE
CAS-699: fixed failing tests

### DIFF
--- a/backend/tests/test_utils/proposal_utils.go
+++ b/backend/tests/test_utils/proposal_utils.go
@@ -35,7 +35,7 @@ var (
 		Strategy:     &tokenWeightedDefault,
 		Status:       &published,
 		Block_height: &blockHeight,
-		TallyMethod: "single-choice",
+		TallyMethod:  "single-choice",
 	}
 
 	DraftProposalStruct = models.Proposal{
@@ -44,6 +44,14 @@ var (
 		Status: &draft,
 	}
 )
+
+type PaginatedResponseWithProposal struct {
+	Data         []models.Proposal `json:"data"`
+	Start        int               `json:"start"`
+	Count        int               `json:"count"`
+	TotalRecords int               `json:"totalRecords"`
+	Next         string            `json:"next"`
+}
 
 func (otu *OverflowTestUtils) GetProposalsForCommunityAPI(communityId int) *httptest.ResponseRecorder {
 	req, _ := http.NewRequest("GET", "/communities/"+strconv.Itoa(communityId)+"/proposals", nil)
@@ -169,11 +177,26 @@ func (otu *OverflowTestUtils) GenerateUpdatedDraftProposalPayload(
 	return &payload
 }
 
+func (otu *OverflowTestUtils) GenerateUpdateProposalStatusPayload(
+	signer string,
+	status string,
+) *models.UpdateProposalRequestPayload {
+	payload := models.UpdateProposalRequestPayload{Proposal: &models.Proposal{Status: &status}}
+	timestamp := fmt.Sprint(time.Now().UnixNano() / int64(time.Millisecond))
+	compositeSignatures := otu.GenerateCompositeSignatures(signer, timestamp)
+	account, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", signer))
+	payload.Signing_addr = fmt.Sprintf("0x%s", account.Address().String())
+	payload.Timestamp = timestamp
+	payload.Composite_signatures = compositeSignatures
+
+	return &payload
+}
+
 func (otu *OverflowTestUtils) GenerateUpdateProposalBodyPayload(
 	signer string,
-	updatedProposal *models.Proposal,
+	proposal *models.Proposal,
 ) *models.UpdateProposalRequestPayload {
-	payload := models.UpdateProposalRequestPayload{Proposal: updatedProposal}
+	payload := models.UpdateProposalRequestPayload{Proposal: proposal}
 	timestamp := fmt.Sprint(time.Now().UnixNano() / int64(time.Millisecond))
 	compositeSignatures := otu.GenerateCompositeSignatures(signer, timestamp)
 	account, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", signer))


### PR DESCRIPTION
There are failing tests on `release-v2.0.0`. For some reason after release-v.6.0 was merged into release-v.2.0.0 we had some missing structs and functions. I'm not sure exactly what happened, but this PR fixes the broken tests.

•adds missing utils response struct and utils generate method. 